### PR TITLE
Add mkdir64 to complete needs from glusterfs

### DIFF
--- a/lib/libspl/getmntany.c
+++ b/lib/libspl/getmntany.c
@@ -221,6 +221,20 @@ openat64(int dirfd, const char *path, int flags, ...)
 }
 
 int
+mkdirat64(int dirfd, const char *path, mode_t mode)
+{
+	int cwdfd, newdirfd;
+
+	if ((cwdfd = chdir_block_begin(dirfd)) == -1)
+		return (-1);
+
+	newdirfd = mkdir(path, mode);
+
+	chdir_block_end(cwdfd);
+	return (newdirfd);
+}
+
+int
 fstatat64(int dirfd, const char *path, struct stat *statbuf, int flag)
 {
 	int cwdfd, error;

--- a/lib/libspl/include/sys/mnttab.h
+++ b/lib/libspl/include/sys/mnttab.h
@@ -78,4 +78,6 @@ extern void statfs2mnttab(struct statfs *sfs, struct mnttab *mp);
 #define	AT_SYMLINK_FOLLOW	0x400
 extern int fstatat64(int, const char *, struct stat *, int);
 
+extern int mkdirat64(int, const char *, mode_t);
+
 #endif


### PR DESCRIPTION
I am trying to get glusterfs working for OS X. I need the ...at64 functions from zfs, but libspl misses the mkdirat to be complete. 
