### PR TITLE
Tautological Compare warning fixes

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1457,11 +1457,6 @@ dmu_read_iokit(objset_t *os, uint64_t object, uint64_t *offset,
                 (*size) -= done;
             }
 
-            if (done < 0) {
-                err = EIO;
-                break;
-            }
-
             //size -= tocpy;
         }
     }
@@ -1532,11 +1527,6 @@ dmu_write_iokit_dnode(dnode_t *dn, uint64_t *offset, uint64_t position,
             if (done > 0) {
                 *offset += done;
                 *size -= done;
-            }
-
-            if (done < 0) {
-                err = EIO;
-                break;
             }
         }
     }


### PR DESCRIPTION
Since unsigned integers can never be negative, some code can never be
reached and can safely be removed as dead code.

The underlying function zvolIO_kit_read/zvolIO_kit_write is using IOMemoryDescriptor::writeBytes/IOMemoryDescriptor::readBytes respective, which also have an unsigned return value. It is also documented to never return a negative number.

https://developer.apple.com/library/mac/documentation/Kernel/Reference/IOMemoryDescriptor_reference/translated_content/IOMemoryDescriptor.html#//apple_ref/cpp/instm/IOMemoryDescriptor/writeBytes/IOByteCount
