### PR TITLE
Evil Merge restoration zfs_context.h

### DIFF
--- a/include/sys/zfs_context_kernel.h
+++ b/include/sys/zfs_context_kernel.h
@@ -62,7 +62,9 @@ extern "C" {
 #include <sys/time.h>
 #include <vm/seg_kmem.h>
 #include <sys/zone.h>
+#include <sys/sdt.h>
 #include <sys/zfs_debug.h>
+#include <sys/zfs_delay.h>
 #include <sys/fm/fs/zfs.h>
 #include <sys/sunddi.h>
 #include <sys/ctype.h>


### PR DESCRIPTION
The file zfs_context.h seems to be the victim of an incorrect merge
resolution. Changes from upstream were lost, likely since the local
zfs_context.h file was split into zfs_context_kernel.h and
zfs_context_userland.h. This commit restores some of those lost changes.
The evil merge was fdbc078c0e88e6086fcb312b443be6581c578359.

This commit only restores part of the changes and was created by hand-picking them.
A more in-depth solution would be to redo the whole merge correctly and then apply
or merge the changes committed since the evil merge.
