### PR TITLE
Stack overflow fix

### DIFF
--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -387,7 +387,7 @@ zfs_add_option(zfs_handle_t *zhp, char *options, int len,
 #endif
 
 static int
-zfs_add_options(zfs_handle_t *zhp, uint64_t *flags)
+zfs_add_options(zfs_handle_t *zhp, int *flags)
 {
 	int error = 0;
     char *source;


### PR DESCRIPTION
The flags variable is of type int, when reading from and writing to
it via an uint64_t *, the behavior is undefined but can be really bad.
