### PR TITLE
ZFS ACL overflow fix

### DIFF
--- a/module/zfs/zfs_acl.c
+++ b/module/zfs/zfs_acl.c
@@ -1800,7 +1800,7 @@ zfs_getacl(znode_t *zp, struct kauth_acl **aclpp, boolean_t skipaclcheck,
     u_int32_t  ace_flags = 0;
     kauth_ace_rights_t  rights = 0;
     guid_t          *guidp;
-    uid_t           who;
+    uint64_t        who;
     uint32_t        access_mask;
     uint16_t        flags;
     uint16_t        type;


### PR DESCRIPTION
Passing a pointer to uid_t (a 32 bit type) to zfs_acl_next_ace, which
writes to it assuming it is a uint64_t pointer has the chance to
overwrite unrelated stack memory, such as access_mask.
