### PR TITLE
Issue183 with snapdev

### DIFF
--- a/include/sys/zvol.h
+++ b/include/sys/zvol.h
@@ -66,7 +66,6 @@ typedef struct zvol_state {
 	znode_t zv_znode;	/* for range locking */
 	dmu_buf_t *zv_dbuf;	/* bonus handle */
 	void *zv_iokitdev;	/* C++ reference to IOKit class */
-	uint64_t zv_openflags;	/* Remember flags used at open */
 	char zv_bsdname[MAXPATHLEN];
 	/* 'rdiskX' name, use [1] for diskX */
 } zvol_state_t;

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -1320,7 +1320,7 @@ dsl_dataset_snapshot(nvlist_t *snaps, nvlist_t *props, nvlist_t *errors)
 		for (pair = nvlist_next_nvpair(snaps, NULL); pair != NULL;
 		    pair = nvlist_next_nvpair(snaps, pair)) {
 			char *snapname = nvpair_name(pair);
-			zvol_create_minors(snapname);
+			zvol_create_minor(snapname);
 		}
 	}
 #endif

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -3213,9 +3213,11 @@ zfs_ioc_snapshot(const char *poolname, nvlist_t *innvl, nvlist_t *outnvl)
 
 	error = dsl_dataset_snapshot(snaps, props, outnvl);
 
+#if 0
 #ifdef _KERNEL
 	if (error == 0)
 		zvol_create_minors(poolname);
+#endif
 #endif
 
 	return (error);

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -2878,8 +2878,21 @@ zvol_create_minors(const char *name)
 #ifdef LINUX
 	if (!zvol_inhibit_dev)
 #endif
+
+	/*
+	 * Iterate over dataset/zvol and children, including snapshots.
+	 * However, if a snapshot was passed as the argument, create the
+	 * minor directly. dmu_objset_find will not fire when passing a
+	 * snapshot as its argument.
+	 */
+	if (strchr(name, '@') == NULL) {
+		/* Dataset or zvol */
 		error = dmu_objset_find((char *)name, zvol_create_minors_cb,
 		    NULL, DS_FIND_CHILDREN | DS_FIND_SNAPSHOTS);
+	} else {
+		/* Snapshot */
+		error = zvol_create_minor(name);
+	}
 
 	return (SET_ERROR(error));
 }


### PR DESCRIPTION
@lundman Could you review these additional changes?
* snapdev was not being checked (default hidden) which can create lots of additional zvol devices
* changing snapdev on live zvols works in the same was as on ZoL:
  * if the zvol is in use, it changes the property but leaves the zvol minor unchanged.
  * after unmounting volumes from an open zvol, you can re-issue `zfs set snapdev=hidden` and it will go away
* uses the dmu_objset_find -> zvol_create_minors_cb style from ZoL 
* snapshot zvol_create_minors checked all the datasets and snapshots in the pool, even though dsl_dataset_snapshot attempted to call zvol_create_minors on each new snapshot (but failed).