### PR TITLE
Remove duplicate pointer in arc_buf_t

### DIFF
--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -61,7 +61,6 @@ struct arc_buf {
 	arc_buf_hdr_t		*b_hdr;
 	arc_buf_t		*b_next;
 	kmutex_t		b_evict_lock;
-    krwlock_t       b_data_lock;
 	void			*b_data;
 	arc_evict_func_t	*b_efunc;
 	void			*b_private;


### PR DESCRIPTION
Should have been renamed to b_evict_lock, instead we have both.