### PR TITLE
Import root check

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -2298,6 +2298,22 @@ zpool_do_import(int argc, char **argv)
 			nvlist_free(policy);
 			return (1);
 		}
+#ifdef __APPLE__
+		/*
+		 * Check for the SYS_CONFIG privilege.  We do this explicitly
+		 * here because otherwise any attempt to import pools will
+		 * report "no such pool available."
+		 */
+		if (argc > 0 && !priv_ineffect(PRIV_SYS_CONFIG)) {
+			(void) fprintf(stderr, gettext("cannot "
+			    "import pools: permission denied\n"));
+			if (searchdirs != NULL)
+				free(searchdirs);
+
+			nvlist_free(policy);
+			return (1);
+		}
+#endif /* __APPLE__ */
 	}
 
 	/*


### PR DESCRIPTION
This will keep us from scaring users with false negatives that say "no such pool available."