### PR TITLE
Correct hardlink usage with Finder. Introduce name cache

### DIFF
--- a/include/sys/zfs_vfsops.h
+++ b/include/sys/zfs_vfsops.h
@@ -81,10 +81,6 @@ struct zfsvfs {
         list_t          z_all_znodes;   /* all vnodes in the fs */
         kmutex_t        z_znodes_lock;  /* lock for z_all_znodes */
         struct vnode   *z_ctldir;      /* .zfs directory pointer */
-        time_t          z_mount_time;           /* mount timestamp (for Spotlight) */
-        time_t          z_last_unmount_time;    /* unmount timestamp (for Spotlight) */
-        time_t          z_last_mtime_synced;    /* last fs mtime synced to disk */
-        struct vnode   *z_mtime_vp;            /* znode utilized for the fs mtime. */
         boolean_t       z_show_ctldir;  /* expose .zfs in the root dir */
         boolean_t       z_issnap;       /* true if this is a snapshot */
         boolean_t	    z_use_fuids;	/* version allows fuids */
@@ -93,16 +89,24 @@ struct zfsvfs {
 	    boolean_t       z_xattr_sa;     /* allow xattrs to be stores as SA */
         uint64_t        z_version;
         uint64_t        z_shares_dir;   /* hidden shares dir */
-	uint64_t	z_notification_conditions; /* used for HFSIOC_VOLUME_STATUS */
-	uint64_t	z_freespace_notify_warninglimit; /* HFSIOC_ vfs notification - number of free blocks */
-	uint64_t	z_freespace_notify_dangerlimit; /* HFSIOC_ vfs notification - number of free blocks */
-	uint64_t	z_freespace_notify_desiredlevel; /* HFSIOC_ vfs notification - number of free blocks */
         kmutex_t	    z_lock;
+
 #ifdef __APPLE__
+        time_t          z_mount_time;           /* mount timestamp (for Spotlight) */
+        time_t          z_last_unmount_time;    /* unmount timestamp (for Spotlight) */
         boolean_t       z_xattr;        /* enable atimes mount option */
 
+	    avl_tree_t   	z_hardlinks;    /* linkid hash avl tree for vget */
+	    avl_tree_t   	z_hardlinks_linkid; /* same tree, sorted on linkid */
+	    krwlock_t	    z_hardlinks_lock;	/* lock to access z_hardlinks */
+
+	    uint64_t	    z_notification_conditions; /* HFSIOC_VOLUME_STATUS */
+	    uint64_t	    z_freespace_notify_warninglimit; /* HFSIOC_ - number of free blocks */
+	    uint64_t	    z_freespace_notify_dangerlimit; /* HFSIOC_ - number of free blocks */
+	    uint64_t	    z_freespace_notify_desiredlevel; /* HFSIOC_ - number of free blocks */
+
 #ifdef APPLE_SA_RECOVER
-	uint64_t z_recover_parent;/* Temporary holder until SA corruption are gone */
+	    uint64_t        z_recover_parent;/* Temporary holder until SA corruption are gone */
 #endif /* APPLE_SA_RECOVER */
 
 #endif
@@ -114,12 +118,19 @@ struct zfsvfs {
         kmutex_t        z_hold_mtx[ZFS_OBJ_MTX_SZ];     /* znode hold locks */
 };
 
+
 #ifdef __APPLE__
-	struct vnodecreate {
-		thread_t thread;
-		list_node_t link;
-	};
+struct hardlinks_struct {
+	avl_node_t hl_node;
+	avl_node_t hl_node_linkid;
+	uint64_t hl_parent;     // parentid of entry
+	uint64_t hl_fileid;     // the fileid (z_id) for vget
+	uint32_t hl_linkid;     // the linkid, persistent over renames
+	char hl_name[PATH_MAX]; // cached name for vget
+};
+typedef struct hardlinks_struct hardlinks_t;
 #endif
+
 
 #define	ZFS_SUPER_MAGIC	0x2fc12fc1
 

--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -246,8 +246,15 @@ typedef struct znode {
 	list_node_t	z_link_reclaim_node;	/* all reclaim znodes in fs link */
     uint32_t    z_vid;  /* OSX vnode_vid */
 	uint32_t    z_document_id;
-    /* Track vnop_lookup name for Finder - not for anything else */
-    char        z_finder_hardlink_name[MAXPATHLEN];
+
+    /* Track vnop_lookup name for Finder - as Apple asks for va_name in
+	 * vnop_getattr and vfs_vget, it is expensive to lookup the name.
+	 * We also need to keep hardlink parentid to return the correct id in
+	 * getattr
+	 */
+    char        z_name_cache[MAXPATHLEN];
+	uint64_t    z_finder_parentid;
+
 	boolean_t   z_fastpath;
 	boolean_t   z_reclaim_reentry; /* vnode_create()->vnop_reclaim() */
 	uint64_t    z_write_gencount;

--- a/module/zfs/zfs_vfsops.c
+++ b/module/zfs/zfs_vfsops.c
@@ -119,6 +119,52 @@ int  zfs_module_stop(kmod_info_t *ki, void *data);
 extern int getzfsvfs(const char *dsname, zfsvfs_t **zfvp);
 
 
+/*
+ * AVL tree of hardlink entries, which we need to map for Finder. The va_linkid
+ * needs to be unique for each hardlink target, as well as, return the znode
+ * in vget(va_linkid). Unfortunately, the va_linkid is 32bit (lost in the
+ * syscall translation to userland struct). We sort the AVL tree by
+ * -> directory id
+ *       -> z_id
+ *              -> name
+ *
+ */
+static int hardlinks_compare(const void *arg1, const void *arg2)
+{
+	const hardlinks_t *node1 = arg1;
+	const hardlinks_t *node2 = arg2;
+	int value;
+	if (node1->hl_parent > node2->hl_parent)
+		return 1;
+	if (node1->hl_parent < node2->hl_parent)
+		return -1;
+	if (node1->hl_fileid > node2->hl_fileid)
+		return 1;
+	if (node1->hl_fileid < node2->hl_fileid)
+		return -1;
+
+	value = strncmp(node1->hl_name, node2->hl_name, PATH_MAX);
+	if (value < 0) return -1;
+	if (value > 0) return 1;
+	return 0;
+}
+
+/*
+ * Lookup same information from linkid, to get at parentid, objid and name
+ */
+static int hardlinks_compare_linkid(const void *arg1, const void *arg2)
+{
+	const hardlinks_t *node1 = arg1;
+	const hardlinks_t *node2 = arg2;
+	if (node1->hl_linkid > node2->hl_linkid)
+		return 1;
+	if (node1->hl_linkid < node2->hl_linkid)
+		return -1;
+	return 0;
+}
+
+
+
 // move these structs to _osx once wrappers are updated
 
 /*
@@ -1345,6 +1391,13 @@ zfsvfs_create(const char *osname, zfsvfs_t **zfvp)
 	rrm_init(&zfsvfs->z_teardown_lock, B_FALSE);
 	rw_init(&zfsvfs->z_teardown_inactive_lock, NULL, RW_DEFAULT, NULL);
 	rw_init(&zfsvfs->z_fuid_lock, NULL, RW_DEFAULT, NULL);
+#ifdef __APPLE__
+	rw_init(&zfsvfs->z_hardlinks_lock, NULL, RW_DEFAULT, NULL);
+	avl_create(&zfsvfs->z_hardlinks, hardlinks_compare,
+			   sizeof (hardlinks_t), offsetof(hardlinks_t, hl_node));
+	avl_create(&zfsvfs->z_hardlinks_linkid, hardlinks_compare_linkid,
+			   sizeof (hardlinks_t), offsetof(hardlinks_t, hl_node_linkid));
+#endif
 	for (i = 0; i != ZFS_OBJ_MTX_SZ; i++)
 		mutex_init(&zfsvfs->z_hold_mtx[i], NULL, MUTEX_DEFAULT, NULL);
 
@@ -1460,6 +1513,21 @@ zfsvfs_free(zfsvfs_t *zfsvfs)
 	rrm_destroy(&zfsvfs->z_teardown_lock);
 	rw_destroy(&zfsvfs->z_teardown_inactive_lock);
 	rw_destroy(&zfsvfs->z_fuid_lock);
+#ifdef __APPLE__
+	dprintf("ZFS: Unloading hardlink AVLtree: %lu\n",
+		   avl_numnodes(&zfsvfs->z_hardlinks));
+	void *cookie = NULL;
+	hardlinks_t *hardlink;
+	rw_destroy(&zfsvfs->z_hardlinks_lock);
+	while((hardlink = avl_destroy_nodes(&zfsvfs->z_hardlinks_linkid, &cookie))) {
+	}
+	cookie = NULL;
+	while((hardlink = avl_destroy_nodes(&zfsvfs->z_hardlinks, &cookie))) {
+		kmem_free(hardlink, sizeof(*hardlink));
+	}
+	avl_destroy(&zfsvfs->z_hardlinks);
+	avl_destroy(&zfsvfs->z_hardlinks_linkid);
+#endif
 	for (i = 0; i != ZFS_OBJ_MTX_SZ; i++)
 		mutex_destroy(&zfsvfs->z_hold_mtx[i]);
 	kmem_free(zfsvfs, sizeof (zfsvfs_t));
@@ -2665,7 +2733,9 @@ zfs_vfs_unmount(struct mount *mp, int mntflags, vfs_context_t context)
     zfsvfs_t *zfsvfs = vfs_fsprivate(mp);
 	//kthread_t *td = (kthread_t *)curthread;
 	objset_t *os;
+#ifndef __APPLE__
 	cred_t *cr =  (cred_t *)vfs_context_ucred(context);
+#endif
 	int ret;
 
     dprintf("+unmount\n");
@@ -2678,7 +2748,6 @@ zfs_vfs_unmount(struct mount *mp, int mntflags, vfs_context_t context)
 		    ZFS_DELEG_PERM_MOUNT, cr))
 			return (ret);
 	}
-
 #endif
 	/*
 	 * We purge the parent filesystem's vfsp as the parent filesystem
@@ -2875,14 +2944,13 @@ zfs_vfs_unmount(struct mount *mp, int mntflags, vfs_context_t context)
 }
 
 
-
 static int
 zfs_vget_internal(zfsvfs_t *zfsvfs, ino64_t ino, vnode_t **vpp)
 {
 	znode_t		*zp;
 	int 		err;
 
-    dprintf("vget get %d\n", ino);
+    dprintf("vget get %llu\n", ino);
 	/*
 	 * zfs_zget() can't operate on virtual entries like .zfs/ or
 	 * .zfs/snapshot/ directories, that's why we return EOPNOTSUPP.
@@ -2892,7 +2960,36 @@ zfs_vget_internal(zfsvfs_t *zfsvfs, ino64_t ino, vnode_t **vpp)
 	    (zfsvfs->z_shares_dir != 0 && ino == zfsvfs->z_shares_dir))
 		return (EOPNOTSUPP);
 
-    /* We can not be locked during zget. */
+
+	/*
+	 * Check to see if we expect to find this in the hardlink avl tree of
+	 * hashes. Use the MSB set high as indicator.
+	 */
+	hardlinks_t *findnode = NULL;
+	if ((1<<31) & ino) {
+		hardlinks_t searchnode;
+		avl_index_t loc;
+
+		dprintf("ZFS: vget looking for (%x,%u)\n", ino, ino);
+
+		searchnode.hl_linkid = ino;
+
+		rw_enter(&zfsvfs->z_hardlinks_lock, RW_READER);
+		findnode = avl_find(&zfsvfs->z_hardlinks_linkid, &searchnode, &loc);
+		rw_exit(&zfsvfs->z_hardlinks_lock);
+
+		if (findnode) {
+			dprintf("ZFS: vget found (%llu, %llu, %u): '%s'\n",
+				   findnode->hl_parent,
+				   findnode->hl_fileid, findnode->hl_linkid,
+				   findnode->hl_name);
+			// Lookup the actual zp instead
+			ino = findnode->hl_fileid;
+		} // findnode
+	} // MSB set
+
+
+	/* We can not be locked during zget. */
 
 	err = zfs_zget(zfsvfs, ino, &zp);
 
@@ -2934,23 +3031,45 @@ zfs_vget_internal(zfsvfs_t *zfsvfs, ino64_t ino, vnode_t **vpp)
 	} else {
 		uint64_t parent;
 
-		/* Lookup name from ID, grab parent */
-		VERIFY(sa_lookup(zp->z_sa_hdl, SA_ZPL_PARENT(zfsvfs),
-                         &parent, sizeof (parent)) == 0);
+		// if its a hardlink cache
+		if (findnode) {
 
-#if 1
-		if (zap_value_search(zfsvfs->z_os, parent, zp->z_id,
-							 ZFS_DIRENT_OBJ(-1ULL), name) == 0) {
+			dprintf("vget: updating vnode to '%s' and parent %llu\n",
+				   findnode->hl_name, findnode->hl_parent);
+			vnode_update_identity(*vpp, NULL, findnode->hl_name,
+								  strlen(findnode->hl_name),
+								  findnode->hl_parent,
+								  VNODE_UPDATE_NAME|VNODE_UPDATE_PARENT);
+			strlcpy(zp->z_name_cache, findnode->hl_name, PATH_MAX);
+			zp->z_finder_parentid = findnode->hl_parent;
 
-			dprintf("vget: set name '%s'\n", name);
-			vnode_update_identity(*vpp, NULL, name,
-								  strlen(name), 0,
+		// If we already have the name, cached in zfs_vnop_lookup
+		} else if (zp->z_name_cache[0]) {
+
+			dprintf("vget: cached name '%s'\n", zp->z_name_cache);
+			vnode_update_identity(*vpp, NULL, zp->z_name_cache,
+								  strlen(zp->z_name_cache), 0,
 								  VNODE_UPDATE_NAME);
-		} else {
-			dprintf("vget: unable to get name for %u\n", zp->z_id);
-		} // !zap_search
-#endif
 
+			/* If needed, if findnode is set, we can update the parentid too */
+
+		} else {
+
+			/* Lookup name from ID, grab parent */
+			VERIFY(sa_lookup(zp->z_sa_hdl, SA_ZPL_PARENT(zfsvfs),
+							 &parent, sizeof (parent)) == 0);
+
+			if (zap_value_search(zfsvfs->z_os, parent, zp->z_id,
+								 ZFS_DIRENT_OBJ(-1ULL), name) == 0) {
+
+				dprintf("vget: set name '%s'\n", name);
+				vnode_update_identity(*vpp, NULL, name,
+									  strlen(name), 0,
+									  VNODE_UPDATE_NAME);
+			} else {
+				dprintf("vget: unable to get name for %llu\n", zp->z_id);
+			} // !zap_search
+		}
 	} // rootid
 
 

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -4370,6 +4370,17 @@ top:
 				 */
 				vn_renamepath(tdvp, ZTOV(szp), tnm,
 				    strlen(tnm));
+
+#ifdef __APPLE__
+				/* Update cached name - for vget, and access without
+				 * calling vnop_lookup first - it is easier to clear
+				 * it out and let getattr look it up if needed.
+				 */
+				if (tzp) tzp->z_name_cache[0] = 0;
+				if (szp) szp->z_name_cache[0] = 0;
+
+#endif
+
 			} else {
 				/*
 				 * At this point, we have successfully created

--- a/module/zfs/zfs_vnops_osx.c
+++ b/module/zfs/zfs_vnops_osx.c
@@ -446,15 +446,87 @@ zfs_vnop_ioctl(struct vnop_ioctl_args *ap)
 			}
 			break;
 
-
 		case HFS_PREV_LINK:
 		case HFS_NEXT_LINK:
-			// HFS has a facility to efficiently iterate the collection
-			// of hardlinks pointing to an object, ZFS does not
-			// implement something like this.
-			//
-			// In the mean time, we will just reply with "what hardlink?"
-			*(uint32_t *)ap->a_data = 0;
+		{
+			/*
+			 * Find sibling linkids with hardlinks. a_data points to the
+			 * "current" linkid, and look up either prev or next (a_command)
+			 * linkid. Return in a_data.
+			 */
+			uint32_t linkfileid;
+			struct vfsstatfs *vfsp;
+			/* Caller must be owner of file system. */
+			vfsp = vfs_statfs(zfsvfs->z_vfs);
+			if ((kauth_cred_getuid(cr) == 0) &&
+				kauth_cred_getuid(cr) != vfsp->f_owner) {
+				error = EACCES;
+				goto out;
+			}
+			/* Target vnode must be file system's root. */
+			if (!vnode_isvroot(ap->a_vp)) {
+				error = EINVAL;
+				goto out;
+			}
+			linkfileid = *(uint32_t *)ap->a_data;
+			if (linkfileid < 16 ) { /* kHFSFirstUserCatalogNodeID */
+				error = EINVAL;
+				goto out;
+			}
+
+			/* Attempt to find the linkid in the hardlink_link AVL tree
+			 * If found, call to get prev or next.
+			 */
+			hardlinks_t searchnode, *findnode, *sibling;
+			avl_index_t loc;
+			searchnode.hl_linkid = linkfileid;
+
+			rw_enter(&zfsvfs->z_hardlinks_lock, RW_READER);
+			findnode = avl_find(&zfsvfs->z_hardlinks_linkid, &searchnode, &loc);
+
+			if (!findnode) {
+				rw_exit(&zfsvfs->z_hardlinks_lock);
+				*(uint32_t *)ap->a_data = 0;
+				dprintf("ZFS: HFS_NEXT_LINK/HFS_PREV_LINK %u not found\n",
+					linkfileid);
+				goto out;
+			}
+
+			if (ap->a_command != HFS_NEXT_LINK) {
+
+				// Walk the next nodes, looking for fileid to match
+				while ((sibling = AVL_NEXT(&zfsvfs->z_hardlinks_linkid,
+										   findnode)) != NULL) {
+					if (findnode->hl_fileid == sibling->hl_fileid)
+						break;
+				}
+
+			} else {
+
+				// Walk the prev nodes, looking for fileid to match
+				while ((sibling = AVL_PREV(&zfsvfs->z_hardlinks_linkid,
+										   findnode)) != NULL) {
+					if (findnode->hl_fileid == sibling->hl_fileid)
+						break;
+				}
+
+			}
+			rw_exit(&zfsvfs->z_hardlinks_lock);
+
+			dprintf("ZFS: HFS_%s_LINK %u sibling %u\n",
+					(ap->a_command != HFS_NEXT_LINK) ? "NEXT" : "PREV",
+					linkfileid,
+					sibling ? sibling->hl_linkid : 0);
+
+			// Did we get a new node?
+			if (sibling == NULL) {
+				*(uint32_t *)ap->a_data = 0;
+				goto out;
+			}
+
+			*(uint32_t *)ap->a_data = sibling->hl_linkid;
+			error = 0;
+		}
 			break;
 
 		case HFS_RESIZE_PROGRESS:
@@ -672,27 +744,39 @@ zfs_vnop_access(struct vnop_access_args *ap)
 	return (error);
 }
 
-void
-zfs_finder_keep_hardlink(struct vnode *vp, char *filename)
+
+/*
+ * hard link references?
+ * Read the comment in zfs_getattr_znode_unlocked for the reason
+ * for this hackery. Since getattr(VA_NAME) is extremely common
+ * call in OSX, we opt to always save the name. We need to be careful
+ * as zfs_dirlook can return ctldir node as well (".zfs").
+ * Hardlinks also need to be able to return the correct parentid.
+ */
+static void zfs_cache_name(struct vnode *vp, struct vnode *dvp, char *filename)
 {
-	if ((vp != NULL) && !zfsctl_is_node(vp)) {
-		znode_t *zp = VTOZ(vp);
-		if (zp != NULL) {
-			/*
-			 * hard link references? Read the comment in
-			 * zfs_getattr_znode_unlocked for the reason for this
-			 * hackery.
-			 */
-			if ((zp->z_links > 1) &&
-			    (IFTOVT((mode_t)zp->z_mode) == VREG)) {
-				dprintf("keep_hardlink: %p has refs %llu\n", vp,
-				    zp->z_links);
-				strlcpy(zp->z_finder_hardlink_name, filename,
-				    MAXPATHLEN);
-			}
-		} //zp
-	} //vp
+	znode_t *zp;
+	if (!vp ||
+		!filename ||
+		!filename[0] ||
+		zfsctl_is_node(vp) ||
+		!VTOZ(vp))
+		return;
+
+	zp = VTOZ(vp);
+
+	strlcpy(zp->z_name_cache,
+			filename,
+			MAXPATHLEN);
+
+	// If hardlink, remember the parentid.
+	if ((zp->z_links > 1) &&
+		(IFTOVT((mode_t)zp->z_mode) == VREG) &&
+		dvp) {
+		zp->z_finder_parentid = VTOZ(dvp)->z_id;
+	}
 }
+
 
 int
 zfs_vnop_lookup(struct vnop_lookup_args *ap)
@@ -742,7 +826,7 @@ zfs_vnop_lookup(struct vnop_lookup_args *ap)
 				error = 0;
 				goto exit;	/* Positive cache, return it */
 			}
-			/* Release iocount held by cache_lookip */
+			/* Release iocount held by cache_lookup */
 			vnode_put(*ap->a_vpp);
 		}
 		/* Negatives are only followed if not CREATE, from HFS+. */
@@ -794,14 +878,19 @@ zfs_vnop_lookup(struct vnop_lookup_args *ap)
 
 
 exit:
-	/* Set both for lookup and positive cache */
+
+#ifdef __APPLE__
 	if (!error)
-		zfs_finder_keep_hardlink(*ap->a_vpp,
-		    filename ? filename : cnp->cn_nameptr);
+		zfs_cache_name(*ap->a_vpp, ap->a_dvp,
+					   filename ? filename : cnp->cn_nameptr);
+#endif
+
+	dprintf("-vnop_lookup %d : dvp %llu '%s'\n", error, VTOZ(ap->a_dvp)->z_id,
+			filename ? filename : cnp->cn_nameptr);
+
 	if (filename)
 		kmem_free(filename, filename_num_bytes);
 
-	dprintf("-vnop_lookup %d\n", error);
 	return (error);
 }
 
@@ -840,6 +929,143 @@ zfs_vnop_create(struct vnop_create_args *ap)
 	return (error);
 }
 
+
+static int zfs_remove_hardlink(struct vnode *vp, struct vnode *dvp)
+{
+	/*
+	 * Because we store hash of hardlinks in an AVLtree, we need to remove
+	 * any entries in it upon deletion. Since it is complicated to know
+	 * if an entry was a hardlink, we simply check if the avltree has the
+	 * name.
+	 */
+	hardlinks_t searchnode, *findnode;
+	avl_index_t loc;
+
+	if (!vp || !VTOZ(vp)) return 1;
+	if (!dvp || !VTOZ(dvp)) return 1;
+	znode_t *zp = VTOZ(vp);
+	znode_t *dzp = VTOZ(dvp);
+	zfsvfs_t *zfsvfs = zp->z_zfsvfs;
+	int ishardlink = 0;
+
+	ishardlink = ((zp->z_links > 1) && (IFTOVT((mode_t)zp->z_mode) == VREG)) ?
+		1 : 0;
+
+	if (!ishardlink) return 0;
+
+	// Attempt to remove from hardlink avl, if its there
+	searchnode.hl_parent = dzp->z_id == zfsvfs->z_root ? 2 : dzp->z_id;
+	searchnode.hl_fileid = zp->z_id;
+	strlcpy(searchnode.hl_name, zp->z_name_cache, PATH_MAX);
+
+	rw_enter(&zfsvfs->z_hardlinks_lock, RW_READER);
+	findnode = avl_find(&zfsvfs->z_hardlinks, &searchnode, &loc);
+	rw_exit(&zfsvfs->z_hardlinks_lock);
+
+	// Found it? remove it
+	if (findnode) {
+		rw_enter(&zfsvfs->z_hardlinks_lock, RW_WRITER);
+		avl_remove(&zfsvfs->z_hardlinks, findnode);
+		avl_remove(&zfsvfs->z_hardlinks_linkid, findnode);
+		rw_exit(&zfsvfs->z_hardlinks_lock);
+		kmem_free(findnode, sizeof(*findnode));
+		dprintf("ZFS: removed hash '%s'\n", zp->z_name_cache);
+		return 1;
+	}
+	return 0;
+}
+
+
+static int zfs_rename_hardlink(struct vnode *vp,
+							   struct vnode *fdvp, struct vnode *tdvp,
+							   char *from, char *to)
+{
+	/*
+	 * Because we store hash of hardlinks in an AVLtree, we need to update
+	 * any entries in it upon rename. Since it is complicated to know
+	 * if an entry was a hardlink, we simply check if the avltree has the
+	 * name.
+	 */
+	hardlinks_t searchnode, *findnode, *delnode;
+	avl_index_t loc;
+	uint64_t parent_fid, parent_tid;
+	int ishardlink = 0;
+
+	if (!vp || !VTOZ(vp)) return 0;
+	znode_t *zp = VTOZ(vp);
+	zfsvfs_t *zfsvfs = zp->z_zfsvfs;
+
+	ishardlink = ((zp->z_links > 1) && (IFTOVT((mode_t)zp->z_mode) == VREG)) ?
+		1 : 0;
+
+	if (!ishardlink) return 0;
+
+	if (!fdvp || !VTOZ(fdvp)) return 0;
+	parent_fid = VTOZ(fdvp)->z_id;
+	parent_fid = parent_fid == zfsvfs->z_root ? 2 : parent_fid;
+
+	if (!tdvp || !VTOZ(tdvp)) {
+		parent_tid = parent_fid;
+	} else {
+		parent_tid = VTOZ(tdvp)->z_id;
+		parent_tid = parent_tid == zfsvfs->z_root ? 2 : parent_tid;
+	}
+
+	dprintf("ZFS: looking to rename hardlinks (%llu,%llu,%s)\n",
+		   parent_fid, zp->z_id, from);
+
+	// Attempt to remove from hardlink avl, if its there
+	searchnode.hl_parent = parent_fid;
+	searchnode.hl_fileid = zp->z_id;
+	strlcpy(searchnode.hl_name, from, PATH_MAX);
+
+	rw_enter(&zfsvfs->z_hardlinks_lock, RW_READER);
+	findnode = avl_find(&zfsvfs->z_hardlinks, &searchnode, &loc);
+	rw_exit(&zfsvfs->z_hardlinks_lock);
+
+	// Found it? update it
+	if (findnode) {
+
+		rw_enter(&zfsvfs->z_hardlinks_lock, RW_WRITER);
+
+		// Technically, we do not need to re-do the _linkid AVL here.
+		avl_remove(&zfsvfs->z_hardlinks, findnode);
+		avl_remove(&zfsvfs->z_hardlinks_linkid, findnode);
+
+		// If we already have a hashid for "to" and the rename presumably
+		// unlinked it, we need to remove it first.
+		searchnode.hl_parent = parent_tid;
+		strlcpy(searchnode.hl_name, to, PATH_MAX);
+		delnode = avl_find(&zfsvfs->z_hardlinks, &searchnode, &loc);
+		if (delnode) {
+			dprintf("ZFS: apparently %llu:'%s' exists, deleting\n",
+				   parent_tid, to);
+			avl_remove(&zfsvfs->z_hardlinks, delnode);
+			avl_remove(&zfsvfs->z_hardlinks_linkid, delnode);
+			kmem_free(delnode, sizeof(*delnode));
+		}
+
+		dprintf("ZFS: renamed hash %llu (%llu:'%s' to %llu:'%s'): %s\n",
+			   zp->z_id,
+			   parent_fid, from,
+			   parent_tid, to,
+			   delnode ? "deleted":"");
+
+		// Update source node to new hash, and name.
+		findnode->hl_parent = parent_tid;
+		strlcpy(findnode->hl_name, to, PATH_MAX);
+
+		avl_add(&zfsvfs->z_hardlinks, findnode);
+		avl_add(&zfsvfs->z_hardlinks_linkid, findnode);
+
+		rw_exit(&zfsvfs->z_hardlinks_lock);
+
+		return 1;
+	}
+	return 0;
+}
+
+
 int
 zfs_vnop_remove(struct vnop_remove_args *ap)
 #if 0
@@ -863,9 +1089,13 @@ zfs_vnop_remove(struct vnop_remove_args *ap)
 	 */
 	error = zfs_remove(ap->a_dvp, ap->a_cnp->cn_nameptr, cr, ct,
 	    /* flags */0);
-	if (!error)
+	if (!error) {
 		cache_purge(ap->a_vp);
 
+		zfs_remove_hardlink(ap->a_vp,
+							ap->a_dvp);
+
+	}
 	return (error);
 }
 
@@ -1213,6 +1443,11 @@ zfs_vnop_rename(struct vnop_rename_args *ap)
 		cache_purge_negatives(ap->a_fdvp);
 		cache_purge_negatives(ap->a_tdvp);
 		cache_purge(ap->a_fvp);
+
+		zfs_rename_hardlink(ap->a_fvp,
+							ap->a_fdvp, ap->a_tdvp,
+							ap->a_fcnp->cn_nameptr,
+							ap->a_tcnp->cn_nameptr);
 		if (ap->a_tvp)
 			cache_purge(ap->a_tvp);
 	}
@@ -1886,7 +2121,6 @@ zfs_vnop_pageoutv2(struct vnop_pageout_args *ap)
 	}
 
 
-  top:
 	tx = dmu_tx_create(zfsvfs->z_os);
 	dmu_tx_hold_write(tx, zp->z_id, ap->a_f_offset, ap->a_size);
 

--- a/module/zfs/zfs_vnops_osx_lib.c
+++ b/module/zfs/zfs_vnops_osx_lib.c
@@ -176,6 +176,7 @@ zfs_getattr_znode_unlocked(struct vnode *vp, vattr_t *vap)
 #ifdef VNODE_ATTR_va_addedtime
 	uint64_t addtime[2] = { 0 };
 #endif
+	int ishardlink = 0;
 
     //printf("getattr_osx\n");
 
@@ -209,6 +210,8 @@ zfs_getattr_znode_unlocked(struct vnode *vp, vattr_t *vap)
 
     mutex_enter(&zp->z_lock);
 
+	ishardlink = ((zp->z_links > 1) && (IFTOVT((mode_t)zp->z_mode) == VREG)) ?
+		1 : 0;
 
 	/* Work out which SA we need to fetch */
 
@@ -269,6 +272,11 @@ zfs_getattr_znode_unlocked(struct vnode *vp, vattr_t *vap)
 	else
 		vap->va_parentid = parent;
 
+	// Hardlinks: Return cached parentid, make it 2 if root.
+	if (ishardlink)
+		vap->va_parentid = (zp->z_finder_parentid == zfsvfs->z_root) ?
+			2 : zp->z_finder_parentid;
+
 	vap->va_iosize = zp->z_blksz ? zp->z_blksz : zfsvfs->z_max_blksz;
 	//vap->va_iosize = 512;
     VATTR_SET_SUPPORTED(vap, va_iosize);
@@ -314,25 +322,41 @@ zfs_getattr_znode_unlocked(struct vnode *vp, vattr_t *vap)
              * If we also want ATTR_CMN_* lookups to work, we need to
              * set a unique va_linkid for each entry, and based on the
              * linkid in the lookup, return the correct name.
-             * It is set in zfs_finder_keep_hardlink()
+             * It is set in zfs_vnop_lookup().
+			 * Since zap_value_search is a slow call, we only use it if
+			 * we have not cached the name in vnop_lookup.
              */
 
-            if ((zp->z_links > 1) && (IFTOVT((mode_t)zp->z_mode) == VREG) &&
-                zp->z_finder_hardlink_name[0]) {
+			// Cached name, from vnop_lookup
+			if (ishardlink &&
+                zp->z_name_cache[0]) {
 
-                strlcpy(vap->va_name, zp->z_finder_hardlink_name,
+                strlcpy(vap->va_name, zp->z_name_cache,
+                        MAXPATHLEN);
+                VATTR_SET_SUPPORTED(vap, va_name);
+
+			} else if (zp->z_name_cache[0]) {
+
+                strlcpy(vap->va_name, zp->z_name_cache,
                         MAXPATHLEN);
                 VATTR_SET_SUPPORTED(vap, va_name);
 
             } else {
-            if (zap_value_search(zfsvfs->z_os, parent, zp->z_id,
-                                 ZFS_DIRENT_OBJ(-1ULL), vap->va_name) == 0)
-                VATTR_SET_SUPPORTED(vap, va_name);
+
+				// Go find the name.
+				if (zap_value_search(zfsvfs->z_os, parent, zp->z_id,
+									 ZFS_DIRENT_OBJ(-1ULL), vap->va_name) == 0) {
+					VATTR_SET_SUPPORTED(vap, va_name);
+					// Might as well keep this name too.
+					strlcpy(zp->z_name_cache, vap->va_name,
+							MAXPATHLEN);
+				} // zap_value_search
 
 			}
+
 			dprintf("getattr: %p return name '%s':%04llx\n", vp,
-				   vap->va_name,
-				   vap->va_linkid);
+					vap->va_name,
+					vap->va_linkid);
 
 
         } else {
@@ -354,8 +378,64 @@ zfs_getattr_znode_unlocked(struct vnode *vp, vattr_t *vap)
 	}
 
     if (VATTR_IS_ACTIVE(vap, va_linkid)) {
-        VATTR_RETURN(vap, va_linkid, vap->va_fileid);
-    }
+
+		/* Apple needs a little extra care with HARDLINKs. All hardlink targets
+		 * return the same va_fileid (POSIX) but also return an unique va_linkid
+		 * This we generate by hashing the (unique) name and store as va_linkid.
+		 * However, Finder will call vfs_vget() with linkid and expect to receive
+		 * the link target, so we need to add it to the AVL z_hardlinks.
+		 */
+		if (ishardlink) {
+			hardlinks_t searchnode, *findnode;
+			avl_index_t loc;
+
+			// If we don't have a linkid, make one.
+			searchnode.hl_parent = vap->va_parentid;
+			searchnode.hl_fileid = zp->z_id;
+			strlcpy(searchnode.hl_name, zp->z_name_cache, PATH_MAX);
+
+			rw_enter(&zfsvfs->z_hardlinks_lock, RW_READER);
+			findnode = avl_find(&zfsvfs->z_hardlinks, &searchnode, &loc);
+			rw_exit(&zfsvfs->z_hardlinks_lock);
+
+			if (!findnode) {
+				static uint32_t zfs_hardlink_sequence = 1<<31;
+				// Search again after getting write lock
+				rw_enter(&zfsvfs->z_hardlinks_lock, RW_READER);
+				findnode = avl_find(&zfsvfs->z_hardlinks, &searchnode, &loc);
+				if (!findnode) {
+					// Add hash entry
+					findnode = kmem_alloc(sizeof(hardlinks_t), KM_SLEEP);
+
+					findnode->hl_parent = vap->va_parentid;
+					findnode->hl_fileid = zp->z_id;
+					strlcpy(findnode->hl_name, zp->z_name_cache, PATH_MAX);
+
+					findnode->hl_linkid = zfs_hardlink_sequence;
+					atomic_inc_32(&zfs_hardlink_sequence);
+
+					avl_add(&zfsvfs->z_hardlinks, findnode);
+					avl_add(&zfsvfs->z_hardlinks_linkid, findnode);
+					dprintf("ZFS: Inserted new hardlink node (%llu,%llu,'%s') <-> (%x,%u)\n",
+						   findnode->hl_parent,
+						   findnode->hl_fileid, findnode->hl_name,
+						   findnode->hl_linkid, findnode->hl_linkid	);
+				} // findnode2
+				rw_exit(&zfsvfs->z_hardlinks_lock);
+
+			} // findnode
+
+			// return made, or found, linkid.
+			VATTR_RETURN(vap, va_linkid, findnode->hl_linkid);
+
+		} else { // !ishardlink - use same as fileid
+
+			VATTR_RETURN(vap, va_linkid, vap->va_fileid);
+
+		}
+
+	} // active linkid
+
 	if (VATTR_IS_ACTIVE(vap, va_filerev)) {
         VATTR_RETURN(vap, va_filerev, 0);
     }
@@ -423,6 +503,15 @@ zfs_getattr_znode_unlocked(struct vnode *vp, vattr_t *vap)
         kauth_cred_uid2guid(zp->z_gid, &vap->va_guuid);
     }
 #endif
+
+	if (ishardlink)
+		dprintf("ZFS:getattr(%s,%llu,%llu) parent %llu: cache_parent %llu\n",
+			   VATTR_IS_ACTIVE(vap, va_name) ? vap->va_name : zp->z_name_cache,
+			   vap->va_fileid,
+			   VATTR_IS_ACTIVE(vap, va_linkid) ? vap->va_linkid : 0,
+			   vap->va_parentid,
+			zp->z_finder_parentid);
+
 
 	vap->va_supported |= ZFS_SUPPORTED_VATTRS;
 	uint64_t missing = 0;

--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -729,7 +729,8 @@ zfs_znode_alloc(zfsvfs_t *zfsvfs, dmu_buf_t *db, int blksz,
 	zp->z_uid = 0;
 	zp->z_gid = 0;
 	zp->z_size = 0;
-	zp->z_finder_hardlink_name[0] = 0;
+	zp->z_name_cache[0] = 0;
+	zp->z_finder_parentid = 0;
 
 	vp = ZTOV(zp); /* Does nothing in OSX */
 


### PR DESCRIPTION
Finder required va_linkid to be unique among all siblings of hardlinks (that
share va_fileid). Including vget support on linkid. Implement using
AVL tree nodes of generated linkids.

This also allowed for ioctl HFS_NEXT_LINK to be implemented.

Add name caching to znode, due to OSX high usage of va_name in vnop_getattr.