### PR TITLE
Remove idle timeout key from launchd jobs

### DIFF
--- a/etc/launchd/daemons/org.openzfsonosx.InvariantDisks.plist.in
+++ b/etc/launchd/daemons/org.openzfsonosx.InvariantDisks.plist.in
@@ -12,7 +12,5 @@
 	<true/>
 	<key>KeepAlive</key>
 	<true/>
-	<key>TimeOut</key>
-	<integer>0</integer>
 </dict>
 </plist>

--- a/etc/launchd/daemons/org.openzfsonosx.zpool-import-all.plist.in
+++ b/etc/launchd/daemons/org.openzfsonosx.zpool-import-all.plist.in
@@ -14,7 +14,5 @@
 	<string>/private/var/log/org.openzfsonosx.zpool-import-all.err</string>
 	<key>StandardOutPath</key>
 	<string>/private/var/log/org.openzfsonosx.zpool-import-all.log</string>
-	<key>TimeOut</key>
-	<integer>0</integer>
 </dict>
 </plist>


### PR DESCRIPTION
The key idle timeout was removed in 10.10. Furthermore, it is the job's responsibility to terminate itself when it has idled for a specific time. This was seemingly only a key to send an idle timeout value to the job itself. launchd won't kill the job due to any idle timeout settings.