### PR TITLE
fix launchctl remove / load race in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -76,13 +76,13 @@ if CONFIG_USER
 install-data-hook::
 	@echo
 	for plistfile in $(launchddaemon_DATA); do \
-		label=`defaults read "$$PWD"/"$$plistfile" Label`; \
-		echo "Attempting to remove $$label ..."; \
-		$(DESTDIR)/bin/launchctl remove "$$label" \
-		    || echo "Ignoring errors"; \
 		bn=`basename "$$plistfile"`; \
+		echo "Attempting to unload $$bn ..."; \
+		$(DESTDIR)/bin/launchctl unload -F \
+		$(DESTDIR)$(launchddaemondir)/"$$bn" \
+		    || echo "Ignoring errors"; \
 		echo "Attempting to load $$bn ..."; \
-		$(DESTDIR)/bin/launchctl load -w \
+		$(DESTDIR)/bin/launchctl load -wF \
 		$(DESTDIR)$(launchddaemondir)/"$$bn" \
 		    || echo "Ignoring errors"; \
 	done


### PR DESCRIPTION
On "make install", InvariantDisks typically does not exit
after its launchctl remove before the launchctl load.
This leads to an error message and IVD not running after
"make install".

Switch "remove" to "unload", and add "-F" flags to the
unload and load.