### PR TITLE
Include notice on spotlight disable apple.browse

### DIFF
--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -1435,7 +1435,8 @@ Controls whether the dataset is managed from a non-global zone. Zones are a Sola
 .RS 4n
 Equivalent to mount option browse/nobrowse. This option indicates that
 the mount point should not be visible via the GUI (i.e., appear on the
-Desktop as a separate volume).
+Desktop as a separate volume). Setting it to off will result in 
+Spotlight being unavailable for the specified mount point.
 .RE
 
 .sp


### PR DESCRIPTION
When com.apple.browse=off, spotlight will be completely unavailable which is not obvious from the man page and is potentially significant and hard to track errors resulting from. This attempts to fix #380