### PR TITLE
Use a shared lock for online expansion

### DIFF
--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -2404,7 +2404,7 @@ zpool_relabel_disk(libzfs_handle_t *hdl, const char *path, const char *msg)
 {
 	int fd, error;
 
-	if ((fd = open(path, O_RDWR|O_DIRECT)) < 0) {
+	if ((fd = open(path, O_RDWR|O_DIRECT|O_SHLOCK)) < 0) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "cannot "
 		    "relabel '%s': unable to open device: %d"), path, errno);
 		return (zfs_error(hdl, EZFS_OPENFAILED, msg));


### PR DESCRIPTION
ZFS's online expansion feature (zpool online -e and autoexpand) needs to
be able to rewrite the partition table of an in-use device.

On OS X, this isn't possible unless we use a shared lock (O_SHLOCK) in
zpool_relabel_disk(). In the same situation, illumos and ZoL are able to
use O_RDWR|O_NDELAY and O_RDWR|O_DIRECT, respectively.

Closes #247