### PR TITLE
Change import-all script to also use -d /var/run/disk/by-id

### DIFF
--- a/etc/launchd/launchd.d/zpool-import-all.sh.in
+++ b/etc/launchd/launchd.d/zpool-import-all.sh.in
@@ -32,7 +32,7 @@ sleep 10
 echo "Running zpool import -a"
 date
 
-"${ZPOOL}" import -a
+"${ZPOOL}" import -a -d /var/run/disk/by-id
 ret=$?
 
 date


### PR DESCRIPTION
Add -d /var/run/disk/by-id to improve the safety of the zpool-import-all.sh script and also get correct media-id devs in the pools after bootup.