### PR TITLE
Replaced `ZED_SCRIPT_DIR` with `ZED_ZEDLET_DIR`

### DIFF
--- a/cmd/zed/zed.d/snapshot.mount.sh
+++ b/cmd/zed/zed.d/snapshot.mount.sh
@@ -8,7 +8,7 @@ function notify {
 	sudo -u "$(stat -f '%Su' /dev/console)" /usr/bin/osascript -e 'display notification "'"$1"'" with title "'"$2"'"'
 }
 
-test -f "${ZED_SCRIPT_DIR}/zed.rc" && . "${ZED_SCRIPT_DIR}/zed.rc"
+test -f "${ZED_ZEDLET_DIR}/zed.rc" && . "${ZED_ZEDLET_DIR}/zed.rc"
 
 test -n "${ZEVENT_POOL}" || exit 5
 test -n "${ZEVENT_SUBCLASS}" || exit 5

--- a/cmd/zed/zed.d/zpool.import.sh
+++ b/cmd/zed/zed.d/zpool.import.sh
@@ -8,7 +8,7 @@ function notify {
 	sudo -u "$(stat -f '%Su' /dev/console)" /usr/bin/osascript -e 'display notification "'"$1"'" with title "'"$2"'"'
 }
 
-test -f "${ZED_SCRIPT_DIR}/zed.rc" && . "${ZED_SCRIPT_DIR}/zed.rc"
+test -f "${ZED_ZEDLET_DIR}/zed.rc" && . "${ZED_ZEDLET_DIR}/zed.rc"
 
 test -n "${ZEVENT_POOL}" || exit 5
 test -n "${ZEVENT_SUBCLASS}" || exit 5


### PR DESCRIPTION
Some script files still used the outdated `ZED_SCRIPT_DIR` variable - it's called `ZED_ZEDLET_DIR` now.

(Talked about this with @ilovezfs via IRC)