### PR TITLE
zvols cloned with readonly=on are initially read-write

### DIFF
--- a/include/sys/zfs_vfsops.h
+++ b/include/sys/zfs_vfsops.h
@@ -46,8 +46,9 @@ struct znode;
 /* #define WITH_SEARCHFS */
 /* #define WITH_READDIRATTR */
 #define	HAVE_NAMED_STREAMS 1
-#define	HAVE_PAGEOUT_V2 1
-#define HIDE_TRIVIAL_ACL 1
+#define	HAVE_PAGEOUT_V2    1
+#define	HAVE_PAGEIN_V2     1
+#define HIDE_TRIVIAL_ACL   1
 #endif
 
 

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -891,7 +891,9 @@ dmu_objset_create_sync(void *arg, dmu_tx_t *tx)
 	}
 
 	spa_history_log_internal_ds(ds, "create", tx, "");
+#ifdef linux /* XXX */
 	zvol_create_minors(dp->dp_spa, doca->doca_name, B_TRUE);
+#endif
 
 	dsl_dataset_rele(ds, FTAG);
 	dsl_dir_rele(pdd, FTAG);
@@ -986,7 +988,9 @@ dmu_objset_clone_sync(void *arg, dmu_tx_t *tx)
 	dsl_dataset_name(origin, namebuf);
 	spa_history_log_internal_ds(ds, "clone", tx,
 	    "origin=%s (%llu)", namebuf, origin->ds_object);
+#ifdef linux /* XXX */
 	zvol_create_minors(dp->dp_spa, doca->doca_clone, B_TRUE);
+#endif
 	dsl_dataset_rele(ds, FTAG);
 	dsl_dataset_rele(origin, FTAG);
 	dsl_dir_rele(pdd, FTAG);


### PR DESCRIPTION
`zfs create -V <size> -o readonly=on <dataset>`
or
`zfs clone -o readonly=on <src> <dest>`

would create a read-write zvol device that could (incorrectly) be written to.

This is due to the create and clone ioctl setting local properties after creating a new dmu_objset, where dmu_objset_create and _clone calls zvol_create_minors on completion.

zfs receive and zpool import were correctly handling readonly zvols, since the property is already set on the dataset by the time zvol_create_minors is called.

Workarounds: export and import pool, use send and receive to a new zvol

Fixed by disabling zvol_create_minors calls from dmu_objset_create_sync and dmu_objset_clone_sync, and instead calling after local properties have been set from zfs_ioc_create and zfs_ioc_clone.