### PR TITLE
Add missing section of the illumos 5767 commit

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -4560,9 +4560,10 @@ print_list_stats(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
 		}
 	}
 
-	if (children > 0) {
-		(void) printf("%-*s      -      -      -      -      -      "
-		    "-\n", cb->cb_namewidth, "cache");
+	if (nvlist_lookup_nvlist_array(nv, ZPOOL_CONFIG_SPARES, &child,
+	    &children) == 0 && children > 0) {
+		/* LINTED E_SEC_PRINTF_VAR_FMT */
+		(void) printf(dashes, cb->cb_namewidth, "spare");
 		for (c = 0; c < children; c++) {
 			vname = zpool_vdev_name(g_zfs, zhp, child[c],
 			    cb->cb_name_flags);


### PR DESCRIPTION
We're missing a section of the following commit:
Illumos 5767 - fix several problems with zfs test suite
illumos: https://github.com/illumos/illumos-gate/commit/52244c0958bdf281ca42932b449f644b4decfdc2
ZoL: https://github.com/zfsonlinux/zfs/commit/8e4c5c9a9406f4708f2f05ab711a82c0465a0ebb

This commit applies the missing section.

Closes #514.