### PR TITLE
Fix mountpoint=none bugs

### DIFF
--- a/lib/libzfs/libzfs_changelist.c
+++ b/lib/libzfs/libzfs_changelist.c
@@ -504,6 +504,13 @@ change_one(zfs_handle_t *zhp, void *data)
 			 * This is necessary when the original mountpoint
 			 * is legacy or none.
 			 */
+#ifdef __APPLE__
+			if (zhp->zfs_type == ZFS_TYPE_SNAPSHOT &&
+			    clp->cl_prop == ZFS_PROP_MOUNTPOINT) {
+				zfs_close(zhp);
+				return (0);
+			}
+#endif
 			ASSERT(!clp->cl_alldependents);
 			verify(uu_list_insert_before(clp->cl_list,
 			    uu_list_first(clp->cl_list), cn) == 0);

--- a/lib/libzfs/libzfs_changelist.c
+++ b/lib/libzfs/libzfs_changelist.c
@@ -510,8 +510,12 @@ change_one(zfs_handle_t *zhp, void *data)
 				zfs_close(zhp);
 				return (0);
 			}
-#endif
+
+			ASSERT(!clp->cl_alldependents ||
+			    clp->cl_realprop == ZFS_PROP_NAME);
+#else
 			ASSERT(!clp->cl_alldependents);
+#endif
 			verify(uu_list_insert_before(clp->cl_list,
 			    uu_list_first(clp->cl_list), cn) == 0);
 		}


### PR DESCRIPTION
On macOS, at least for the time being, we've made mountpoint a valid 
property for snapshots to facilitate mounting them manually, so
change_one has to be able to handle the case where it's called for a
dependent whose parent's mountpoint is none.

Fixes #547 and #548.