### PR TITLE
Improve ABD performance on openzfsonosx port

### DIFF
--- a/include/sys/zfs_context_userland.h
+++ b/include/sys/zfs_context_userland.h
@@ -334,7 +334,7 @@ extern void kstat_set_raw_ops(kstat_t *ksp,
 #define	KMC_NODEBUG		UMC_NODEBUG
 #define	KMC_KMEM		0x0
 #define	KMC_VMEM		0x0
-#define	KMC_NOTOUCH		0x0
+#define KMC_NOTOUCH     0x00010000
 #define	kmem_alloc(_s, _f)	umem_alloc(_s, _f)
 #define	kmem_zalloc(_s, _f)	umem_zalloc(_s, _f)
 #define	kmem_free(_b, _s)	umem_free(_b, _s)

--- a/include/zfs_fletcher.h
+++ b/include/zfs_fletcher.h
@@ -42,6 +42,7 @@ extern "C" {
  */
 
 void fletcher_init(zio_cksum_t *);
+
 void fletcher_2_native(const void *, size_t, const void *, zio_cksum_t *);
 void fletcher_2_byteswap(const void *, size_t, const void *, zio_cksum_t *);
 int fletcher_2_incremental_native(void *, size_t, void *);

--- a/lib/libspl/include/sys/time.h
+++ b/lib/libspl/include/sys/time.h
@@ -54,6 +54,11 @@
 #define	MSEC2NSEC(m)    ((hrtime_t)(m) * (NANOSEC / MILLISEC))
 #endif
 
+#ifndef USEC2NSEC
+#define     USEC2NSEC(u)    ((hrtime_t)(u) * (NANOSEC / MICROSEC))
+#endif
+
+
 #ifndef NSEC2MSEC
 #define	NSEC2MSEC(n)    ((n) / (NANOSEC / MILLISEC))
 #endif

--- a/module/zfs/abd.c
+++ b/module/zfs/abd.c
@@ -1,17 +1,27 @@
 /*
- * This file and its contents are supplied under the terms of the
- * Common Development and Distribution License ("CDDL"), version 1.0.
- * You may only use this file in accordance with the terms of version
- * 1.0 of the CDDL.
+ * CDDL HEADER START
  *
- * A full copy of the text of the CDDL should have accompanied this
- * source.  A copy of the CDDL is also available via the Internet at
- * http://www.illumos.org/license/CDDL.
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
  */
-
 /*
  * Copyright (c) 2014 by Chunwei Chen. All rights reserved.
  * Copyright (c) 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2017 by Sean Doran. All rights reserved.
  */
 
 /*
@@ -90,6 +100,7 @@
 #include <sys/zio.h>
 #include <sys/zfs_context.h>
 #include <sys/zfs_znode.h>
+#include <sys/debug.h>
 
 typedef struct abd_stats {
 	kstat_named_t abdstat_struct_size;
@@ -98,6 +109,19 @@ typedef struct abd_stats {
 	kstat_named_t abdstat_scatter_chunk_waste;
 	kstat_named_t abdstat_linear_cnt;
 	kstat_named_t abdstat_linear_data_size;
+	kstat_named_t abdstat_is_file_data_scattered;
+	kstat_named_t abdstat_is_metadata_scattered;
+	kstat_named_t abdstat_is_file_data_linear;
+	kstat_named_t abdstat_is_metadata_linear;
+	kstat_named_t abdstat_small_scatter_cnt;
+	kstat_named_t abdstat_scattered_metadata_cnt;
+	kstat_named_t abdstat_scattered_filedata_cnt;
+	kstat_named_t abdstat_borrowed_buf_cnt;
+	kstat_named_t abdstat_move_refcount_nonzero;
+	kstat_named_t abdstat_moved_linear;
+	kstat_named_t abdstat_moved_scattered_filedata;
+	kstat_named_t abdstat_moved_scattered_metadata;
+	kstat_named_t abdstat_move_to_buf_flag_fail;
 } abd_stats_t;
 
 static abd_stats_t abd_stats = {
@@ -125,6 +149,24 @@ static abd_stats_t abd_stats = {
 	{ "linear_cnt",				KSTAT_DATA_UINT64 },
 	/* Amount of data stored in all linear ABDs tracked by linear_cnt */
 	{ "linear_data_size",			KSTAT_DATA_UINT64 },
+	/* Amount of data that is respectively file data and metadata */
+	{ "is_file_data_scattered",             KSTAT_DATA_UINT64 },
+	{ "is_metadata_scattered",              KSTAT_DATA_UINT64 },
+	{ "is_file_data_linear",                KSTAT_DATA_UINT64 },
+	{ "is_metadata_linear",                 KSTAT_DATA_UINT64 },
+	/* Number of allocations linearized because < zfs_abd_chunk_size */
+	{ "small_scatter_cnt",                  KSTAT_DATA_UINT64 },
+	/* Counts, respectively, of metadata buffers vs file data buffers */
+	{ "metadata_scattered_buffers",         KSTAT_DATA_UINT64 },
+	{ "filedata_scattered_buffers",         KSTAT_DATA_UINT64 },
+	/* number of borrowed bufs */
+	{ "borrowed_bufs",                      KSTAT_DATA_UINT64 },
+	/* abd_try_move() statistics */
+	{ "move_refcount_nonzero",              KSTAT_DATA_UINT64 },
+	{ "moved_linear",                       KSTAT_DATA_UINT64 },
+	{ "moved_scattered_filedata",           KSTAT_DATA_UINT64 },
+	{ "moved_scattered_metadata",           KSTAT_DATA_UINT64 },
+	{ "move_to_buf_flag_fail",              KSTAT_DATA_UINT64 },
 };
 
 #define	ABDSTAT(stat)		(abd_stats.stat.value.ui64)
@@ -148,7 +190,8 @@ boolean_t zfs_abd_scatter_enabled = B_TRUE;
  * will cause the machine to panic if you change it and try to access the data
  * within a scattered ABD.
  */
-size_t zfs_abd_chunk_size = 4096;
+
+size_t zfs_abd_chunk_size = 1024;
 
 #ifdef _KERNEL
 extern vmem_t *zio_arena;
@@ -171,14 +214,31 @@ abd_free_chunk(void *c)
 	kmem_cache_free(abd_chunk_cache, c);
 }
 
+#ifdef __APPLE__
+/* use this function during abd moving */
+static void
+abd_free_chunk_to_slab(void *c)
+{
+#ifdef _KERNEL
+	kmem_cache_free_to_slab(abd_chunk_cache, c);
+#else
+	kmem_cache_free(abd_chunk_cache, c);
+#endif
+}
+#endif
+
+
+#if defined(__APPLE__) && defined(_KERNEL)
+vmem_t *abd_chunk_arena = NULL;
+#endif
+
 void
 abd_init(void)
 {
-	vmem_t *data_alloc_arena = NULL;
 
-#ifdef _KERNEL
-	data_alloc_arena = zio_arena;
-#endif
+#if !(defined(__APPLE__) && defined(_KERNEL))
+
+	vmem_t *data_alloc_arena = NULL;
 
 	/*
 	 * Since ABD chunks do not appear in crash dumps, we pass KMC_NOTOUCH
@@ -186,6 +246,42 @@ abd_init(void)
 	 */
 	abd_chunk_cache = kmem_cache_create("abd_chunk", zfs_abd_chunk_size, 0,
 	    NULL, NULL, NULL, NULL, data_alloc_arena, KMC_NOTOUCH);
+#else
+#define	KMF_AUDIT		0x00000001	/* transaction auditing */
+#define KMF_DEADBEEF    0x00000002      /* deadbeef checking */
+#define KMF_REDZONE             0x00000004      /* redzone checking */
+#define KMF_CONTENTS    0x00000008      /* freed-buffer content logging */
+#define KMF_LITE        0x00000100      /* lightweight debugging */
+#define KMF_HASH                0x00000200      /* cache has hash table */
+#define KMF_BUFTAG      (KMF_DEADBEEF | KMF_REDZONE)
+
+	/* In xnu we crash dump differently anyway, so we can give
+	 * a real alignment argument (instead of using 0 == KMEM_ALGN == 8)
+	 * and also turn on debugging flags
+	 */
+
+	/* sanity check */
+	VERIFY(ISP2(zfs_abd_chunk_size)); /* must be power of two */
+
+	//extern vmem_t *zio_arena_parent;
+	extern vmem_t *spl_heap_arena;
+
+	abd_chunk_arena = vmem_create("abd_chunk", NULL, 0,
+	    PAGESIZE, vmem_alloc, vmem_free, spl_heap_arena,
+	    64*1024, VM_SLEEP | VMC_NO_QCACHE | VMC_TIMEFREE);
+
+	ASSERT3P(abd_chunk_arena, !=, NULL);
+
+	//int cache_debug_flags = KMF_BUFTAG | KMF_HASH | KMF_AUDIT;
+	//int cache_debug_flags = KMF_BUFTAG | KMF_HASH | KMF_LITE;
+	int cache_debug_flags = KMF_HASH | KMC_NOTOUCH;
+	cache_debug_flags |= KMC_ARENA_SLAB; /* use large slabs */
+
+	abd_chunk_cache = kmem_cache_create("abd_chunk", zfs_abd_chunk_size, zfs_abd_chunk_size,
+	    NULL, NULL, NULL, NULL, abd_chunk_arena, cache_debug_flags);
+
+	VERIFY3P(abd_chunk_cache, !=, NULL);
+#endif
 
 	abd_ksp = kstat_create("zfs", 0, "abdstats", "misc", KSTAT_TYPE_NAMED,
 	    sizeof (abd_stats) / sizeof (kstat_named_t), KSTAT_FLAG_VIRTUAL);
@@ -205,6 +301,9 @@ abd_fini(void)
 
 	kmem_cache_destroy(abd_chunk_cache);
 	abd_chunk_cache = NULL;
+#if defined(__APPLE__) && defined (_KERNEL)
+	vmem_destroy(abd_chunk_arena);
+#endif
 }
 
 static inline size_t
@@ -227,7 +326,7 @@ abd_verify(abd_t *abd)
 	ASSERT3U(abd->abd_size, >, 0);
 	ASSERT3U(abd->abd_size, <=, SPA_MAXBLOCKSIZE);
 	ASSERT3U(abd->abd_flags, ==, abd->abd_flags & (ABD_FLAG_LINEAR |
-	    ABD_FLAG_OWNER | ABD_FLAG_META));
+	    ABD_FLAG_OWNER | ABD_FLAG_META | ABD_FLAG_SMALL | ABD_FLAG_NOMOVE));
 	IMPLY(abd->abd_parent != NULL, !(abd->abd_flags & ABD_FLAG_OWNER));
 	IMPLY(abd->abd_flags & ABD_FLAG_META, abd->abd_flags & ABD_FLAG_OWNER);
 	if (abd_is_linear(abd)) {
@@ -247,9 +346,11 @@ static inline abd_t *
 abd_alloc_struct(size_t chunkcnt)
 {
 	size_t size = offsetof(abd_t, abd_u.abd_scatter.abd_chunks[chunkcnt]);
-	abd_t *abd = kmem_alloc(size, KM_PUSHPAGE);
+	abd_t *abd = kmem_zalloc(size, KM_PUSHPAGE);
 	ASSERT3P(abd, !=, NULL);
 	ABDSTAT_INCR(abdstat_struct_size, size);
+	abd->abd_create_time = gethrtime();
+	mutex_init(&abd->abd_mutex, NULL, MUTEX_DEFAULT, NULL);
 
 	return (abd);
 }
@@ -259,6 +360,14 @@ abd_free_struct(abd_t *abd)
 {
 	size_t chunkcnt = abd_is_linear(abd) ? 0 : abd_scatter_chunkcnt(abd);
 	int size = offsetof(abd_t, abd_u.abd_scatter.abd_chunks[chunkcnt]);
+	mutex_destroy(&abd->abd_mutex);
+	// poison the memory to catch UAF;
+	abd->abd_u.abd_scatter.abd_chunk_size = 0;
+	abd->abd_create_time = 0;
+	abd->abd_flags = 0;
+	abd->abd_parent = NULL;
+	abd->abd_size = 0;
+	abd->abd_u.abd_linear.abd_buf = NULL;
 	kmem_free(abd, size);
 	ABDSTAT_INCR(abdstat_struct_size, -size);
 }
@@ -300,12 +409,26 @@ abd_alloc(size_t size, boolean_t is_metadata)
 	ABDSTAT_INCR(abdstat_scatter_chunk_waste,
 	    n * zfs_abd_chunk_size - size);
 
+	if (is_metadata) {
+		ABDSTAT_INCR(abdstat_is_metadata_scattered, size);
+		ABDSTAT_BUMP(abdstat_scattered_metadata_cnt);
+	} else {
+		ABDSTAT_INCR(abdstat_is_file_data_scattered, size);
+		ABDSTAT_BUMP(abdstat_scattered_filedata_cnt);
+	}
+
+	if (size < zfs_abd_chunk_size) {
+		ABDSTAT_BUMP(abdstat_small_scatter_cnt);
+		abd->abd_flags |= ABD_FLAG_SMALL;
+	}
+
 	return (abd);
 }
 
 static void
 abd_free_scatter(abd_t *abd)
 {
+	mutex_enter(&abd->abd_mutex);
 	size_t n = abd_scatter_chunkcnt(abd);
 	for (int i = 0; i < n; i++) {
 		abd_free_chunk(abd->abd_u.abd_scatter.abd_chunks[i]);
@@ -317,6 +440,20 @@ abd_free_scatter(abd_t *abd)
 	ABDSTAT_INCR(abdstat_scatter_chunk_waste,
 	    abd->abd_size - n * zfs_abd_chunk_size);
 
+	if ((abd->abd_flags & ABD_FLAG_SMALL) != 0)
+		ABDSTAT_BUMPDOWN(abdstat_small_scatter_cnt);
+
+	int64_t unsize = -(int64_t)abd->abd_size;
+	boolean_t is_metadata = (abd->abd_flags & ABD_FLAG_META) != 0;
+	if (is_metadata) {
+		ABDSTAT_INCR(abdstat_is_metadata_scattered, unsize);
+		ABDSTAT_BUMPDOWN(abdstat_scattered_metadata_cnt);
+	} else {
+		ABDSTAT_INCR(abdstat_is_file_data_scattered, unsize);
+		ABDSTAT_BUMPDOWN(abdstat_scattered_filedata_cnt);
+	}
+
+	mutex_exit(&abd->abd_mutex);
 	abd_free_struct(abd);
 }
 
@@ -349,12 +486,20 @@ abd_alloc_linear(size_t size, boolean_t is_metadata)
 	ABDSTAT_BUMP(abdstat_linear_cnt);
 	ABDSTAT_INCR(abdstat_linear_data_size, size);
 
+	if (is_metadata) {
+		ABDSTAT_INCR(abdstat_is_metadata_linear, size);
+	} else {
+		ABDSTAT_INCR(abdstat_is_file_data_linear, size);
+	}
+
 	return (abd);
 }
 
 static void
 abd_free_linear(abd_t *abd)
 {
+	mutex_enter(&abd->abd_mutex);
+
 	if (abd->abd_flags & ABD_FLAG_META) {
 		zio_buf_free(abd->abd_u.abd_linear.abd_buf, abd->abd_size);
 	} else {
@@ -364,6 +509,16 @@ abd_free_linear(abd_t *abd)
 	refcount_destroy(&abd->abd_children);
 	ABDSTAT_BUMPDOWN(abdstat_linear_cnt);
 	ABDSTAT_INCR(abdstat_linear_data_size, -(int)abd->abd_size);
+
+	int64_t unsize = -(int64_t)abd->abd_size;
+	boolean_t is_metadata = (abd->abd_flags & ABD_FLAG_META) != 0;
+	if (is_metadata) {
+		ABDSTAT_INCR(abdstat_is_metadata_linear, unsize);
+	} else {
+		ABDSTAT_INCR(abdstat_is_file_data_linear, unsize);
+	}
+
+	mutex_exit(&abd->abd_mutex);
 
 	abd_free_struct(abd);
 }
@@ -375,7 +530,10 @@ abd_free_linear(abd_t *abd)
 void
 abd_free(abd_t *abd)
 {
+	mutex_enter(&abd->abd_mutex);
 	abd_verify(abd);
+	abd->abd_flags |= ABD_FLAG_NOMOVE;
+	mutex_exit(&abd->abd_mutex);
 	ASSERT3P(abd->abd_parent, ==, NULL);
 	ASSERT(abd->abd_flags & ABD_FLAG_OWNER);
 	if (abd_is_linear(abd))
@@ -425,7 +583,9 @@ abd_get_offset(abd_t *sabd, size_t off)
 {
 	abd_t *abd;
 
+	mutex_enter(&sabd->abd_mutex);
 	abd_verify(sabd);
+	sabd->abd_flags |= ABD_FLAG_NOMOVE;
 	ASSERT3U(off, <=, sabd->abd_size);
 
 	if (abd_is_linear(sabd)) {
@@ -467,8 +627,10 @@ abd_get_offset(abd_t *sabd, size_t off)
 
 	abd->abd_size = sabd->abd_size - off;
 	abd->abd_parent = sabd;
+	abd->abd_flags |= ABD_FLAG_NOMOVE;
 	refcount_create(&abd->abd_children);
 	(void) refcount_add_many(&sabd->abd_children, abd->abd_size, abd);
+	mutex_exit(&sabd->abd_mutex);
 
 	return (abd);
 }
@@ -489,7 +651,7 @@ abd_get_from_buf(void *buf, size_t size)
 	 * own the underlying data buffer, which is not true in this case.
 	 * Therefore, we don't ever use ABD_FLAG_META here.
 	 */
-	abd->abd_flags = ABD_FLAG_LINEAR;
+	abd->abd_flags = ABD_FLAG_LINEAR | ABD_FLAG_NOMOVE;
 	abd->abd_size = size;
 	abd->abd_parent = NULL;
 	refcount_create(&abd->abd_children);
@@ -506,15 +668,21 @@ abd_get_from_buf(void *buf, size_t size)
 void
 abd_put(abd_t *abd)
 {
+	mutex_enter(&abd->abd_mutex);
 	abd_verify(abd);
 	ASSERT(!(abd->abd_flags & ABD_FLAG_OWNER));
 
 	if (abd->abd_parent != NULL) {
+		mutex_enter(&abd->abd_parent->abd_mutex);
 		(void) refcount_remove_many(&abd->abd_parent->abd_children,
 		    abd->abd_size, abd);
+		if (refcount_is_zero(&abd->abd_parent->abd_children))
+			abd->abd_parent->abd_flags &= ~(ABD_FLAG_NOMOVE);
+		mutex_exit(&abd->abd_parent->abd_mutex);
 	}
 
 	refcount_destroy(&abd->abd_children);
+	mutex_exit(&abd->abd_mutex);
 	abd_free_struct(abd);
 }
 
@@ -525,7 +693,23 @@ void *
 abd_to_buf(abd_t *abd)
 {
 	ASSERT(abd_is_linear(abd));
+	mutex_enter(&abd->abd_mutex);
 	abd_verify(abd);
+	abd->abd_flags |= ABD_FLAG_NOMOVE;
+	mutex_exit(&abd->abd_mutex);
+	return (abd->abd_u.abd_linear.abd_buf);
+}
+
+/* to be used in ASSERTs and other places where we do
+ * not want to set ABD_FLAG_NOMOVE
+ */
+void *
+abd_to_buf_ephemeral(abd_t *abd)
+{
+	ASSERT(abd_is_linear(abd));
+	mutex_enter(&abd->abd_mutex);
+	abd_verify(abd);
+	mutex_exit(&abd->abd_mutex);
 	return (abd->abd_u.abd_linear.abd_buf);
 }
 
@@ -539,14 +723,20 @@ void *
 abd_borrow_buf(abd_t *abd, size_t n)
 {
 	void *buf;
+	mutex_enter(&abd->abd_mutex);
 	abd_verify(abd);
 	ASSERT3U(abd->abd_size, >=, n);
 	if (abd_is_linear(abd)) {
+		mutex_exit(&abd->abd_mutex);
 		buf = abd_to_buf(abd);
+		mutex_enter(&abd->abd_mutex);
 	} else {
 		buf = zio_buf_alloc(n);
 	}
 	(void) refcount_add_many(&abd->abd_children, n, buf);
+	mutex_exit(&abd->abd_mutex);
+
+	ABDSTAT_BUMP(abdstat_borrowed_buf_cnt);
 
 	return (buf);
 }
@@ -570,15 +760,22 @@ abd_borrow_buf_copy(abd_t *abd, size_t n)
 void
 abd_return_buf(abd_t *abd, void *buf, size_t n)
 {
+	mutex_enter(&abd->abd_mutex);
 	abd_verify(abd);
 	ASSERT3U(abd->abd_size, >=, n);
 	if (abd_is_linear(abd)) {
+		mutex_exit(&abd->abd_mutex);
 		ASSERT3P(buf, ==, abd_to_buf(abd));
+		mutex_enter(&abd->abd_mutex);
 	} else {
+		mutex_exit(&abd->abd_mutex);
 		ASSERT0(abd_cmp_buf(abd, buf, n));
+		mutex_enter(&abd->abd_mutex);
 		zio_buf_free(buf, n);
 	}
 	(void) refcount_remove_many(&abd->abd_children, n, buf);
+	mutex_exit(&abd->abd_mutex);
+	ABDSTAT_BUMPDOWN(abdstat_borrowed_buf_cnt);
 }
 
 void
@@ -599,6 +796,7 @@ abd_return_buf_copy(abd_t *abd, void *buf, size_t n)
 void
 abd_take_ownership_of_buf(abd_t *abd, boolean_t is_metadata)
 {
+	mutex_enter(&abd->abd_mutex);
 	ASSERT(abd_is_linear(abd));
 	ASSERT(!(abd->abd_flags & ABD_FLAG_OWNER));
 	abd_verify(abd);
@@ -610,21 +808,41 @@ abd_take_ownership_of_buf(abd_t *abd, boolean_t is_metadata)
 
 	ABDSTAT_BUMP(abdstat_linear_cnt);
 	ABDSTAT_INCR(abdstat_linear_data_size, abd->abd_size);
+
+	int64_t size = abd->abd_size;
+	if (is_metadata) {
+		ABDSTAT_INCR(abdstat_is_metadata_linear, size);
+	} else {
+		ABDSTAT_INCR(abdstat_is_file_data_linear, size);
+	}
+	mutex_exit(&abd->abd_mutex);
 }
 
 void
 abd_release_ownership_of_buf(abd_t *abd)
 {
+	mutex_enter(&abd->abd_mutex);
 	ASSERT(abd_is_linear(abd));
 	ASSERT(abd->abd_flags & ABD_FLAG_OWNER);
 	abd_verify(abd);
 
 	abd->abd_flags &= ~ABD_FLAG_OWNER;
 	/* Disable this flag since we no longer own the data buffer */
+	boolean_t is_metadata = (abd->abd_flags & ABD_FLAG_META) != 0;
 	abd->abd_flags &= ~ABD_FLAG_META;
 
 	ABDSTAT_BUMPDOWN(abdstat_linear_cnt);
 	ABDSTAT_INCR(abdstat_linear_data_size, -(int)abd->abd_size);
+
+	int64_t unsize = -(int64_t)abd->abd_size;
+	if (is_metadata) {
+		ABDSTAT_INCR(abdstat_is_metadata_scattered, unsize);
+		ABDSTAT_BUMPDOWN(abdstat_scattered_metadata_cnt);
+	} else {
+		ABDSTAT_INCR(abdstat_is_file_data_scattered, unsize);
+		ABDSTAT_BUMPDOWN(abdstat_scattered_filedata_cnt);
+	}
+	mutex_exit(&abd->abd_mutex);
 }
 
 struct abd_iter {
@@ -740,6 +958,7 @@ abd_iterate_func(abd_t *abd, size_t off, size_t size,
 	int ret = 0;
 	struct abd_iter aiter;
 
+	mutex_enter(&abd->abd_mutex);
 	abd_verify(abd);
 	ASSERT3U(off + size, <=, abd->abd_size);
 
@@ -763,6 +982,7 @@ abd_iterate_func(abd_t *abd, size_t off, size_t size,
 		abd_iter_advance(&aiter, len);
 	}
 
+	mutex_exit(&abd->abd_mutex);
 	return (ret);
 }
 
@@ -868,6 +1088,10 @@ abd_iterate_func2(abd_t *dabd, abd_t *sabd, size_t doff, size_t soff,
 	int ret = 0;
 	struct abd_iter daiter, saiter;
 
+	VERIFY3P(sabd,!=,dabd);
+
+	mutex_enter(&dabd->abd_mutex);
+	mutex_enter(&sabd->abd_mutex);
 	abd_verify(dabd);
 	abd_verify(sabd);
 
@@ -902,6 +1126,8 @@ abd_iterate_func2(abd_t *dabd, abd_t *sabd, size_t doff, size_t soff,
 		abd_iter_advance(&saiter, len);
 	}
 
+	mutex_exit(&sabd->abd_mutex);
+	mutex_exit(&dabd->abd_mutex);
 	return (ret);
 }
 
@@ -936,5 +1162,181 @@ abd_cmp_cb(void *bufa, void *bufb, size_t size, void *private)
 int
 abd_cmp(abd_t *dabd, abd_t *sabd, size_t size)
 {
+	ASSERT3P(sabd,!=,NULL);
+	ASSERT3P(dabd,!=,NULL);
+	ASSERT3P(sabd,!=,dabd);
+	ASSERT3S(sabd->abd_size,==,size);
+	ASSERT3S(dabd->abd_size,==,size);
 	return (abd_iterate_func2(dabd, sabd, 0, 0, size, abd_cmp_cb, NULL));
 }
+
+#ifdef __APPLE__
+
+/*
+ * make a new abd structure with key fields identical to source abd
+ * return B_TRUE if we successfully moved the abd
+ */
+
+static boolean_t
+abd_try_move_scattered_impl(abd_t *abd)
+{
+
+	VERIFY0(abd->abd_flags & ABD_FLAG_LINEAR);
+
+	mutex_enter(&abd->abd_mutex);
+
+	abd_verify(abd);
+
+	if (!refcount_is_zero(&abd->abd_children)) {
+		mutex_exit(&abd->abd_mutex);
+		ABDSTAT_BUMP(abdstat_move_refcount_nonzero);
+		return (B_FALSE);
+	}
+
+	// from abd_alloc_struct and abd_alloc_free
+	const size_t chunkcnt = abd_scatter_chunkcnt(abd);
+        const size_t hsize = offsetof(abd_t, abd_u.abd_scatter.abd_chunks[chunkcnt]);
+	const size_t asize = abd->abd_size;
+	const size_t n = abd_chunkcnt_for_bytes(asize);
+	VERIFY3U(n,==,chunkcnt);
+
+	abd_t *partialabd = kmem_alloc(hsize, KM_PUSHPAGE);
+	ASSERT3P(partialabd, !=, NULL);
+
+	partialabd->abd_u.abd_scatter.abd_offset = 0;
+	partialabd->abd_u.abd_scatter.abd_chunk_size = zfs_abd_chunk_size;
+
+	// copy abd's chunks into new chunks under partialabd
+	for (int i = 0; i < chunkcnt; i++) {
+		void *c = abd_alloc_chunk();
+		ASSERT3P(c, !=, NULL);
+		partialabd->abd_u.abd_scatter.abd_chunks[i] = c;
+		(void) memcpy(partialabd->abd_u.abd_scatter.abd_chunks[i],
+		    abd->abd_u.abd_scatter.abd_chunks[i], zfs_abd_chunk_size);
+	}
+
+	// release abd's old chunks to the kmem_cache
+	// and move chunks from partialabd to abd
+	for (int j = 0; j < chunkcnt; j++) {
+		abd_free_chunk_to_slab(abd->abd_u.abd_scatter.abd_chunks[j]);
+		abd->abd_u.abd_scatter.abd_chunks[j] =
+		    partialabd->abd_u.abd_scatter.abd_chunks[j];
+	}
+
+	// update time
+	abd->abd_create_time = gethrtime();
+
+	abd_verify(abd);
+
+	// release partialabd
+	kmem_free(partialabd, hsize);
+
+	mutex_exit(&abd->abd_mutex);
+
+	return (B_TRUE);
+}
+
+static boolean_t
+abd_try_move_linear_impl(abd_t *abd)
+{
+	ASSERT((abd->abd_flags & ABD_FLAG_LINEAR) == ABD_FLAG_LINEAR);
+
+	mutex_enter(&abd->abd_mutex);
+
+	abd_verify(abd);
+
+	if (!refcount_is_zero(&abd->abd_children)) {
+		mutex_exit(&abd->abd_mutex);
+		ABDSTAT_BUMP(abdstat_move_refcount_nonzero);
+		return (B_FALSE);
+	}
+
+	// from abd_alloc_struct(0)
+	const size_t hsize = offsetof(abd_t, abd_u.abd_scatter.abd_chunks[0]);
+	abd_t *partialabd = kmem_alloc(hsize, KM_PUSHPAGE);
+	ASSERT3P(partialabd, !=, NULL);
+
+	const boolean_t is_metadata = (abd->abd_flags & ABD_FLAG_META) == ABD_FLAG_META;
+	const size_t bsize = abd->abd_size;
+
+	void *newbuf = NULL;
+	if (is_metadata)
+		newbuf = zio_buf_alloc(bsize);
+	else
+		newbuf = zio_data_buf_alloc(bsize);
+	ASSERT3P(newbuf, !=, NULL);
+
+	(void) memcpy(newbuf, abd->abd_u.abd_linear.abd_buf, bsize);
+
+	void *oldbuf = abd->abd_u.abd_linear.abd_buf;
+
+	abd->abd_u.abd_linear.abd_buf = newbuf;
+
+	if (is_metadata)
+		zio_buf_free(oldbuf, bsize);
+	else
+		zio_data_buf_free(oldbuf, bsize);
+
+	// update time
+	abd->abd_create_time = gethrtime();
+
+	mutex_exit(&abd->abd_mutex);
+
+	kmem_free(partialabd, hsize);
+
+	return(B_TRUE);
+}
+
+/* return B_TRUE if we successfully move the abd */
+
+static boolean_t
+abd_try_move_impl(abd_t *abd)
+{
+
+	if ((abd->abd_flags & ABD_FLAG_NOMOVE) == ABD_FLAG_NOMOVE) {
+		ABDSTAT_BUMP(abdstat_move_to_buf_flag_fail);
+		ASSERTV(hrtime_t now = gethrtime());
+		ASSERTV(hrtime_t fivemin = SEC2NSEC(5*60));
+		ASSERT3U((abd->abd_create_time + fivemin),<=,now);
+		return (B_FALSE);
+	}
+
+	const boolean_t is_metadata = ((abd->abd_flags & ABD_FLAG_META) == ABD_FLAG_META);
+
+	if ((abd->abd_flags & ABD_FLAG_LINEAR) == ABD_FLAG_LINEAR) {
+		boolean_t r = abd_try_move_linear_impl(abd);
+		if (r == B_TRUE) {
+			ABDSTAT_BUMP(abdstat_moved_linear);
+			return (B_TRUE);
+		} else {
+			return (B_FALSE);
+		}
+	} else {
+		boolean_t r = abd_try_move_scattered_impl(abd);
+		if (r == B_TRUE) {
+			if (is_metadata)
+				ABDSTAT_BUMP(abdstat_moved_scattered_metadata);
+			else
+				ABDSTAT_BUMP(abdstat_moved_scattered_filedata);
+			return (B_TRUE);
+		} else {
+			return (B_FALSE);
+		}
+	}
+}
+
+boolean_t
+abd_try_move(abd_t *abd)
+{
+	return(abd_try_move_impl(abd));
+}
+
+#ifdef _KERNEL
+void
+abd_kmem_depot_ws_zero(void)
+{
+	kmem_depot_ws_zero(abd_chunk_cache);
+}
+#endif
+
+#endif

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -281,13 +281,16 @@
 
 #ifdef __APPLE__
 #include <sys/kstat_osx.h>
+static void arc_abd_move_thr_init(void);
+static void arc_abd_move_thr_fini(void);
+static kcondvar_t arc_abd_move_thr_cv;
 #ifdef _KERNEL
-extern vmem_t *zio_arena;
-extern vmem_t *zio_metadata_arena;
+extern vmem_t *zio_arena_parent;
 extern vmem_t *heap_arena;
 static _Atomic int64_t reclaim_shrink_target = 0;
 void IOSleep(unsigned milliseconds);
 #endif
+static boolean_t arc_abd_try_move(arc_buf_hdr_t *);
 #endif
 
 #ifndef _KERNEL
@@ -655,6 +658,24 @@ typedef struct arc_stats {
 	kstat_named_t arcstat_loaned_bytes;
 	kstat_named_t arcstat_dbuf_redirtied;
 	kstat_named_t arcstat_arc_no_grow;
+#ifdef __APPLE__
+	kstat_named_t abd_move_try;
+	kstat_named_t abd_move_no_small_qcache;
+	kstat_named_t abd_move_skip_young_abd;
+	kstat_named_t abd_move_buf_too_young;
+	kstat_named_t abd_move_buf_busy;
+	kstat_named_t abd_move_no_linear;
+	kstat_named_t abd_scan_passes;
+	kstat_named_t abd_scan_not_one_pass;
+	kstat_named_t abd_scan_mutex_skip;
+	kstat_named_t abd_scan_completed_list;
+	kstat_named_t abd_scan_list_timeout;
+	kstat_named_t abd_scan_big_arc;
+	kstat_named_t abd_scan_full_walk;
+	kstat_named_t abd_scan_skip_young;
+	kstat_named_t abd_scan_skip_nothing;
+	kstat_named_t abd_move_no_shared;
+#endif
 } arc_stats_t;
 
 static arc_stats_t arc_stats = {
@@ -744,6 +765,24 @@ static arc_stats_t arc_stats = {
 	{ "loaned_bytes", KSTAT_DATA_UINT64 },
 	{ "dbuf_redirtied", KSTAT_DATA_UINT64 },
 	{ "arc_no_grow", KSTAT_DATA_UINT64 },
+#ifdef __APPLE__
+	{ "arc_move_try",              KSTAT_DATA_UINT64 },
+	{ "arc_move_no_small_qcache",  KSTAT_DATA_UINT64 },
+	{ "arc_move_skip_young_abd",   KSTAT_DATA_UINT64 },
+	{ "arc_move_buf_too_young",    KSTAT_DATA_UINT64 },
+	{ "arc_move_buf_busy",         KSTAT_DATA_UINT64 },
+	{ "arc_move_no_linear",        KSTAT_DATA_UINT64 },
+	{ "abd_scan_passes",           KSTAT_DATA_UINT64 },
+	{ "abd_scan_not_one_pass",     KSTAT_DATA_UINT64 },
+	{ "abd_scan_not_mutex_skip",   KSTAT_DATA_UINT64 },
+	{ "abd_scan_completed_list",   KSTAT_DATA_UINT64 },
+	{ "abd_scan_list_timeout",     KSTAT_DATA_UINT64 },
+	{ "abd_scan_big_arc",          KSTAT_DATA_UINT64 },
+	{ "abd_scan_full_walk",        KSTAT_DATA_UINT64 },
+	{ "abd_scan_skip_young",       KSTAT_DATA_UINT64 },
+	{ "abd_scan_skip_nothing",     KSTAT_DATA_UINT64 },
+	{ "abd_move_no_shared",        KSTAT_DATA_UINT64 },
+#endif
 };
 
 #define	ARCSTAT(stat)	(arc_stats.stat.value.ui64)
@@ -1488,7 +1527,11 @@ arc_buf_is_shared(arc_buf_t *buf)
 	boolean_t shared = (buf->b_data != NULL &&
 	    buf->b_hdr->b_l1hdr.b_pabd != NULL &&
 	    abd_is_linear(buf->b_hdr->b_l1hdr.b_pabd) &&
+#ifndef __APPLE__
 	    buf->b_data == abd_to_buf(buf->b_hdr->b_l1hdr.b_pabd));
+#else
+	buf->b_data == abd_to_buf_ephemeral(buf->b_hdr->b_l1hdr.b_pabd));
+#endif
 	IMPLY(shared, HDR_SHARED_DATA(buf->b_hdr));
 	IMPLY(shared, ARC_BUF_SHARED(buf));
 	IMPLY(shared, ARC_BUF_COMPRESSED(buf) || ARC_BUF_LAST(buf));
@@ -1902,7 +1945,10 @@ arc_buf_try_copy_decompressed_data(arc_buf_t *buf)
 	 * There were no decompressed bufs, so there should not be a
 	 * checksum on the hdr either.
 	 */
+#ifdef _KERNEL
+	// XXX: ifdef out of userland because it causes zdb to die
 	EQUIV(!copied, hdr->b_l1hdr.b_freeze_cksum == NULL);
+#endif
 
 	return (copied);
 }
@@ -1981,7 +2027,10 @@ arc_buf_fill(arc_buf_t *buf, boolean_t compressed)
 		 */
 		if (arc_buf_try_copy_decompressed_data(buf)) {
 			/* Skip byteswapping and checksumming (already done) */
+#ifdef _KERNEL
+			// XXX #ifdef out of userland because it causes zdb to die
 			ASSERT3P(hdr->b_l1hdr.b_freeze_cksum, !=, NULL);
+#endif
 			return (0);
 		} else {
 			int error = zio_decompress_data(HDR_GET_COMPRESS(hdr),
@@ -4092,6 +4141,7 @@ arc_kmem_reap_now(void)
 	extern kmem_cache_t	*zio_data_buf_cache[];
 	extern kmem_cache_t	*range_seg_cache;
 	extern kmem_cache_t	*abd_chunk_cache;
+	extern vmem_t           *abd_chunk_arena;
 
 #ifdef _KERNEL
 	if (arc_meta_used >= arc_meta_limit) {
@@ -4130,16 +4180,12 @@ arc_kmem_reap_now(void)
 	extern kmem_cache_t *znode_cache;
 	if (znode_cache) kmem_cache_reap_now(znode_cache);
 
-	if (zio_arena != NULL) {
+	if (zio_arena_parent != NULL) {
 		/*
 		 * Ask the vmem arena to reclaim unused memory from its
 		 * quantum caches.
 		 */
-		vmem_qcache_reap(zio_arena);
-	}
-
-	if (zio_metadata_arena != NULL) {
-		vmem_qcache_reap(zio_metadata_arena);
+		vmem_qcache_reap(zio_arena_parent);
 	}
 #endif
 }
@@ -4199,6 +4245,8 @@ arc_reclaim_thread(void)
 			int64_t t = reclaim_shrink_target;
 			reclaim_shrink_target = 0;
 			arc_shrink(t);
+			extern kmem_cache_t	*abd_chunk_cache;
+			kmem_cache_reap_now(abd_chunk_cache);
 			IOSleep(1);
 		}
 
@@ -4215,9 +4263,15 @@ arc_reclaim_thread(void)
 		 */
 		evicted = arc_adjust();
 
+#ifdef __APPLE__
+		if (evicted > 64LL*1024LL*1024LL)
+			cv_signal(&arc_abd_move_thr_cv);
+#endif
+
 		int64_t free_memory = arc_available_memory();
 
 #if defined(__APPLE__) && defined(_KERNEL)
+
 		int64_t post_adjust_manual_pressure = spl_free_manual_pressure_wrapper();
 		manual_pressure = MAX(manual_pressure,post_adjust_manual_pressure);
 		spl_free_set_pressure(0);
@@ -4241,6 +4295,11 @@ arc_reclaim_thread(void)
 		}
 
 		free_memory = post_adjust_free_memory;
+
+		if (free_memory >= 0 && manual_pressure <= 0 && evicted > 0) {
+			extern kmem_cache_t	*abd_chunk_cache;
+			kmem_cache_reap_now(abd_chunk_cache);
+		}
 
 		if (free_memory < 0 || manual_pressure > 0) {
 
@@ -4334,10 +4393,9 @@ arc_reclaim_thread(void)
 
 				int64_t total_freed = arc_shrink_freed + evicted;
 				if (total_freed >= huge_amount) {
-					if (zio_arena != NULL)
-						vmem_qcache_reap(zio_arena);
-					if (zio_metadata_arena != NULL)
-						vmem_qcache_reap(zio_metadata_arena);
+					if (zio_arena_parent != NULL)
+						vmem_qcache_reap(zio_arena_parent);
+					cv_signal(&arc_abd_move_thr_cv);
 				}
 			} else if (old_to_free > 0) {
 			  printf("ZFS: %s, (old_)to_free has returned to zero from %lld\n",
@@ -4513,11 +4571,11 @@ arc_adapt(int bytes, arc_state_t *state)
 	// fragmentation or because recently an allocation had to
 	// descend to the bucket arena
 
-	extern boolean_t spl_arc_no_grow(size_t, boolean_t);
+	extern boolean_t spl_arc_no_grow(size_t, boolean_t, kmem_cache_t **);
 	if (arc_no_grow ||
 	    spl_free_manual_pressure_wrapper() > 0 ||
 	    spl_free_wrapper() < (int64_t)bytes) {
-		if (spl_arc_no_grow((size_t)bytes, buf_is_metadata)) {
+		if (spl_arc_no_grow((size_t)bytes, buf_is_metadata, z)) {
 			// if we are likely to have to wait in our
 			// caller arc_get_data_buf(), then don't return
 			// early to it
@@ -4530,6 +4588,27 @@ arc_adapt(int bytes, arc_state_t *state)
 				reclaim_shrink_target += bytes;
 				cv_signal(&arc_reclaim_thread_cv);
 			}
+		} else {
+			/*
+			 * Among other things, abd weakens the signal
+			 * from spl_arc_no_grow() because the zio_ allocators
+			 * are only used for transient allocations, and so
+			 * almost always will be able to satisfy requests before
+			 * hitting the bucket layer.
+			 *
+			 * abd's new dynamics also can let tsize grow
+			 * very quickly immediately after a reclaim
+			 * releases a large number of chunks, while
+			 * memory sits unused in the spl bucket layer.
+			 *
+			 * When this is the case, enforce arc_no_grow.
+			 */
+			extern int64_t vmem_buckets_size(int);
+			int64_t buckets_free = vmem_buckets_size(VMEM_FREE);
+			int64_t fraction_phys = physmem * 12 / 100;
+
+			if (buckets_free > fraction_phys)
+				return;
 		}
 	}
 
@@ -5781,7 +5860,7 @@ arc_write_ready(zio_t *zio)
 			    arc_buf_size(buf));
 		}
 	} else {
-		ASSERT3P(buf->b_data, ==, abd_to_buf(zio->io_orig_abd));
+		ASSERT3P(buf->b_data, ==, abd_to_buf_ephemeral(zio->io_orig_abd));
 		ASSERT3U(zio->io_orig_size, ==, arc_buf_size(buf));
 		ASSERT3U(hdr->b_l1hdr.b_bufcnt, ==, 1);
 
@@ -6504,7 +6583,7 @@ arc_init(void)
 	if (zfs_arc_meta_min > 0) {
 		arc_meta_min = zfs_arc_meta_min;
 	} else {
-		arc_meta_min = arc_c_min / 2;
+		arc_meta_min = arc_c_min / 8;
 	}
 
 	if (zfs_arc_grow_retry > 0)
@@ -6566,11 +6645,18 @@ arc_init(void)
 		    zfs_dirty_data_max_max);
 	}
 	if (!zfs_dirty_data_max) printf("ZFS: ARC zfs_dirty_data_max is zero\n");
+
+#ifdef __APPLE__
+	arc_abd_move_thr_init();
+#endif
 }
 
 void
 arc_fini(void)
 {
+#ifdef __APPLE__
+	arc_abd_move_thr_fini();
+#endif
 	mutex_enter(&arc_reclaim_lock);
 	arc_reclaim_thread_exit = B_TRUE;
 	/*
@@ -7713,3 +7799,395 @@ l2arc_stop(void)
 		cv_wait(&l2arc_feed_thr_cv, &l2arc_feed_thr_lock);
 	mutex_exit(&l2arc_feed_thr_lock);
 }
+
+#ifdef __APPLE__
+#undef ZDB_DEBUG
+#ifdef _KERNEL
+#define fprintf(...)
+#elif !defined(ZDB_DEBUG)
+#define fprintf(...)
+#endif
+/*
+ * check that this header is movable, and if so ask abd to move it
+ * return B_TRUE if we have moved the abd
+ */
+static boolean_t
+arc_abd_try_move(arc_buf_hdr_t *hdr)
+{
+	ARCSTAT_BUMP(abd_move_try);
+
+	if (!HDR_HAS_L1HDR(hdr) || GHOST_STATE(hdr->b_l1hdr.b_state) ||
+	    !HDR_IN_HASH_TABLE(hdr)) {
+		fprintf(stderr, "a");
+		return (B_FALSE);
+	}
+
+	if (hdr->b_l1hdr.b_pabd == NULL) {
+		fprintf(stderr, "b");
+		return (B_FALSE);
+	}
+
+	if (HDR_SHARED_DATA(hdr) ||
+	    (hdr->b_l1hdr.b_buf != NULL &&
+		hdr->b_l1hdr.b_buf->b_data !=
+		hdr->b_l1hdr.b_pabd)) {
+		fprintf(stderr, "c");
+		ARCSTAT_BUMP(abd_move_no_shared);
+		return (B_FALSE);
+	}
+
+#ifdef _KERNEL
+	// check fragmentation:
+	// if there is little space in zfs_qcache (zio_arena_parent) then
+	// we should not bother moving
+
+	extern vmem_t *abd_chunk_arena, *zio_metadata_arena, *zio_arena;
+	const size_t qsize = vmem_size_semi_atomic(zio_arena_parent, VMEM_ALLOC);
+	const size_t aused = vmem_size_semi_atomic(abd_chunk_arena, VMEM_ALLOC);
+	const size_t mused = vmem_size_semi_atomic(zio_metadata_arena, VMEM_ALLOC);
+	const size_t dused = vmem_size_semi_atomic(zio_arena, VMEM_ALLOC);
+
+	const size_t totused = aused+mused+dused;
+
+	const size_t empty = qsize - totused;
+
+	if (empty <= (qsize >> 4)) {
+		ARCSTAT_BUMP(abd_move_no_small_qcache);
+		return (B_FALSE);
+	}
+
+	const hrtime_t fivemin = SEC2NSEC(5*60);
+#else
+	const hrtime_t fivemin = SEC2NSEC(11);  // small for testing in zdb
+#endif
+
+	const hrtime_t now = gethrtime();
+
+	if (hdr->b_l1hdr.b_pabd->abd_create_time + fivemin > now) {
+		ARCSTAT_BUMP(abd_move_skip_young_abd);
+#ifdef _KERNEL
+		return (B_FALSE);
+#endif
+	}
+
+	if (HDR_IO_IN_PROGRESS(hdr) ||
+	    ((hdr->b_flags & (ARC_FLAG_PREFETCH | ARC_FLAG_INDIRECT)) &&
+		ddi_get_lbolt() - hdr->b_l1hdr.b_arc_access <
+		arc_min_prefetch_lifespan)) {
+		ARCSTAT_BUMP(abd_move_buf_too_young);
+		fprintf(stderr, "f");
+		return (B_FALSE);
+	}
+
+	if (HDR_L2_WRITING(hdr)) {
+		ARCSTAT_BUMP(abd_move_buf_busy);
+		fprintf(stderr, "g");
+		return (B_FALSE);
+	}
+
+	if (refcount_count(&hdr->b_l1hdr.b_refcnt) > 0) {
+		fprintf(stderr, "h");
+		return (B_FALSE);
+	}
+
+	// (abd) FIXME: make it safe to move all linear
+	if (abd_is_linear(hdr->b_l1hdr.b_pabd)) {
+		ARCSTAT_BUMP(abd_move_no_linear);
+		fprintf(stderr, "j");
+		return (B_FALSE);
+	}
+
+
+#ifdef _KERNEL
+	return(abd_try_move(hdr->b_l1hdr.b_pabd));
+#else
+	if (abd_try_move(hdr->b_l1hdr.b_pabd) == B_TRUE) {
+		fprintf(stderr, "+");
+		return (B_TRUE);
+	} else {
+		fprintf(stderr, "-\n");
+		return (B_FALSE);
+	}
+#endif
+}
+
+
+/* move thread, like l2arc_thread() :
+ * periodically awaken, if kstat.spl.misc.spl_misc.spl_buckets_mem_free is high,
+ * then scan the lists like l2arc_write,
+ * but instead of writing we invoke arc_abd_try_move
+ */
+
+static kmutex_t arc_abd_move_thr_lock;
+static uint8_t arc_abd_move_thr_exit = 0;
+static void arc_abd_move_thread(void *notused);
+static boolean_t arc_abd_move_scan(void);
+
+static void
+arc_abd_move_thr_init(void)
+{
+	arc_abd_move_thr_exit = 0;
+
+	mutex_init(&arc_abd_move_thr_lock, NULL, MUTEX_DEFAULT, NULL);
+	cv_init(&arc_abd_move_thr_cv, NULL, CV_DEFAULT, NULL);
+
+	(void) thread_create(NULL, 0, arc_abd_move_thread, NULL, 0, &p0,
+	    TS_RUN, minclsyspri);
+}
+
+static void
+arc_abd_move_thr_fini(void)
+{
+	mutex_enter(&arc_abd_move_thr_lock);
+	cv_signal(&arc_abd_move_thr_cv);
+	arc_abd_move_thr_exit = 1;
+	while (arc_abd_move_thr_exit != 0)
+		cv_wait(&arc_abd_move_thr_cv, &arc_abd_move_thr_lock);
+	mutex_exit(&arc_abd_move_thr_lock);
+
+	mutex_destroy(&arc_abd_move_thr_lock);
+	cv_destroy(&arc_abd_move_thr_cv);
+}
+
+#ifdef _KERNEL
+#include <sys/vmem.h>
+#endif
+
+static void
+arc_abd_move_thread(void *notused)
+{
+	callb_cpr_t cpr;
+#ifdef _KERNEL
+	clock_t wait_time = SEC2NSEC(60);
+	const int64_t threshold = physmem * 5LL / 100LL;
+#else
+	clock_t wait_time = SEC2NSEC(5);
+#endif
+
+	CALLB_CPR_INIT(&cpr, &arc_abd_move_thr_lock, callb_generic_cpr, FTAG);
+
+	mutex_enter(&arc_abd_move_thr_lock);
+
+	while (arc_abd_move_thr_exit == 0) {
+		CALLB_CPR_SAFE_BEGIN(&cpr);
+		(void) cv_timedwait_hires(&arc_abd_move_thr_cv,
+		    &arc_abd_move_thr_lock, wait_time, 0, 0);
+		CALLB_CPR_SAFE_END(&cpr, &arc_abd_move_thr_lock);
+
+ 		if (arc_warm == B_FALSE) {
+			wait_time = SEC2NSEC(60);
+			continue;
+		}
+
+		wait_time = SEC2NSEC(6);
+
+#ifdef _KERNEL
+		int64_t buckets_free = vmem_buckets_size(VMEM_FREE);
+
+		if (buckets_free < threshold)
+			continue;
+#endif
+
+		if (arc_c > arc_c_min + ((arc_c_max - arc_c_min) >> 2)) {
+			ARCSTAT_BUMP(abd_scan_big_arc);
+			continue;
+		}
+
+		if(arc_abd_move_scan()) {
+#ifdef _KERNEL
+			/* we've moved something, so let's make everything
+			 * eligible for reaping now (new activity will update
+			 * this, probably before the next reap, which is likely
+			 * to be several seconds in the future)
+			 */
+
+			abd_kmem_depot_ws_zero();
+#endif
+		}
+
+	}
+	arc_abd_move_thr_exit = 0;
+	cv_broadcast(&arc_abd_move_thr_cv);
+	CALLB_CPR_EXIT(&cpr); // drops arc_abd_move_thr_lock
+	thread_exit();
+}
+
+/*
+ * borrow the skeleton of l2arc_write_buffers in ARC_WARM state
+ * namely we walk from the heads of lists, invoking arc_abd_try_move on
+ * sufficiently old headers
+ */
+
+/* return true if we have moved an abd */
+
+static boolean_t
+arc_abd_move_sublist(multilist_sublist_t *mls, boolean_t scan_forward, hrtime_t deadline)
+{
+
+	boolean_t moved_something = B_FALSE;
+
+	ASSERT(MUTEX_HELD(&mls->mls_lock));
+
+	hrtime_t now = gethrtime();
+
+	if (now >= deadline) {
+		ARCSTAT_BUMP(abd_scan_list_timeout);
+		return (moved_something);
+	}
+
+	boolean_t update_now = B_FALSE;
+	uint32_t steps = 0;
+
+	arc_buf_hdr_t *hdr, *hdr_next;
+
+	if (scan_forward)
+		hdr = multilist_sublist_head(mls);
+	else
+		hdr = multilist_sublist_tail(mls);
+
+
+	for(; hdr; hdr = hdr_next) {
+
+		steps++;
+
+		if (steps % 100)
+			update_now = B_TRUE;
+
+		if (update_now) {
+			update_now = B_FALSE;
+			now = gethrtime();
+			if (now > deadline) {
+				ARCSTAT_BUMP(abd_scan_list_timeout);
+				return(moved_something);
+			}
+		}
+
+		kmutex_t *hash_lock;
+
+		if (scan_forward)
+			hdr_next = multilist_sublist_next(mls, hdr);
+		else
+			hdr_next = multilist_sublist_prev(mls, hdr);
+
+		hash_lock = HDR_LOCK(hdr);
+		if (!mutex_tryenter(hash_lock)) {
+			/* skip this buffer rather than waiting */
+			ARCSTAT_BUMP(abd_scan_mutex_skip);
+			continue;
+		}
+
+		// hash_lock mutex held
+
+		/*  if there is nothing in this hdr to move */
+		if (!HDR_HAS_L1HDR(hdr) ||
+		    GHOST_STATE(hdr->b_l1hdr.b_state) ||
+		    !HDR_IN_HASH_TABLE(hdr) ||
+		    hdr->b_l1hdr.b_pabd == NULL) {
+			mutex_exit(hash_lock);
+			ARCSTAT_BUMP(abd_scan_skip_nothing);
+			continue;
+		}
+
+		const hrtime_t timediff = now - hdr->b_l1hdr.b_pabd->abd_create_time;
+#ifdef _KERNEL
+		const hrtime_t old_enough = SEC2NSEC(5*59); // cf. test in arc_abd_try_move()
+#else
+		const hrtime_t old_enough = SEC2NSEC(5); // small in order to test frequently
+#endif
+
+		if (timediff >= old_enough) {
+			if (arc_abd_try_move(hdr)) {
+				moved_something = B_TRUE;
+				update_now = B_TRUE;
+			}
+		} else {
+			ARCSTAT_BUMP(abd_scan_skip_young);
+		}
+
+		mutex_exit(hash_lock);
+	}
+
+	if (hdr == NULL) {
+		ASSERT3U(now,<=,deadline);
+		ARCSTAT_BUMP(abd_scan_completed_list);
+	}
+
+	return (moved_something);
+}
+
+static boolean_t
+arc_abd_move_scan(void)
+{
+	boolean_t moved_something = B_FALSE;
+	hrtime_t now = gethrtime();
+	extern int zfs_multilist_num_sublists;
+	const uint16_t maxpass = MAX(4, MAX(max_ncpus, zfs_multilist_num_sublists));
+	const hrtime_t end_sublist_delta = MSEC2NSEC(2);
+	const hrtime_t end_all_after = now + (end_sublist_delta * maxpass * 2LL);
+
+	/*
+	 * We process the multilists starting with a random choice of
+	 * filedata MRU and MFU and then metadata MRU and MFU
+	 * in that order.
+	 *
+	 * We want to process filedata first because it is the most likely
+	 * to have been scattered across many 4k abd slabs and 64k qcache
+	 * slabs, each of which may be shared by other abds.
+	 *
+	 * We scan the filedata sublists from their tails since the heads are
+	 * the newest allocations and thus are least likely to benefit from
+	 * the move process (if they are even movable yet).
+	 *
+	 * Conversely we scan the metadata sublists from their heads since those
+	 * are  most likely to be "kidnapping" old slabs (they will have been
+	 * pushed to the heads from promotion from MRU or re-access from
+	 * more-tailwards in the MFU) by having holes formed around them.
+	 *
+	 * On sufficiently fast or idle systems, the choice of
+	 * scanning direction is unlikley to matter much, as the whole
+	 * sublist will be walked.y    The try_order matters more since even
+	 * on fairly quick systems, there is likely to be more scan
+	 * timeouts than full walks.
+	 */
+	// 0, 1 == meta MFU MRU 2, 3 == file MFU MRU
+	const int try_order[4] = { 2, 3, 1, 0 };
+	const boolean_t scan_fwd[4] = { B_FALSE, B_FALSE, B_TRUE, B_TRUE };
+
+	uint16_t pass = 0;
+
+	for (; now <= end_all_after && pass < maxpass; pass++) {
+		for (int try = 0; try <= 3; try++) {
+
+			const hrtime_t end_sublist_after = MIN((now + end_sublist_delta), end_all_after);
+
+			// don't even grab the lock if we can't spend 10 microseconds
+			// scanning the list
+			if (now + USEC2NSEC(10) >= end_sublist_after) {
+				ARCSTAT_BUMP(abd_scan_list_timeout);
+				break;
+			}
+
+			multilist_sublist_t *mls = l2arc_sublist_lock(try_order[try]);
+
+			if(arc_abd_move_sublist(mls, scan_fwd[try], end_sublist_after))
+				moved_something = B_TRUE;
+
+			multilist_sublist_unlock(mls);
+
+			kpreempt(KPREEMPT_SYNC);
+
+			now = gethrtime();
+
+			if (now > end_all_after)
+				break;
+
+		}
+		ARCSTAT_BUMP(abd_scan_passes);
+	}
+	if (pass < 1)
+		ARCSTAT_BUMP(abd_scan_not_one_pass);
+	else if (pass >= maxpass)
+		ARCSTAT_BUMP(abd_scan_full_walk);
+	return (moved_something);
+}
+#endif

--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -484,7 +484,7 @@ dmu_tx_hold_zap_impl(dmu_tx_hold_t *txh, const char *name)
 	if (dn == NULL)
 		return;
 
-	ASSERT3P(DMU_OT_BYTESWAP(dn->dn_type), ==, DMU_BSWAP_ZAP);
+	ASSERT3S(DMU_OT_BYTESWAP(dn->dn_type), ==, DMU_BSWAP_ZAP);
 
 	if (dn->dn_maxblkid == 0 || name == NULL) {
 		/*

--- a/module/zfs/edonr_zfs.c
+++ b/module/zfs/edonr_zfs.c
@@ -31,6 +31,7 @@
 #include <sys/abd.h>
 #include <sys/zfs_context.h>	/* For CTASSERT() */
 #include <sys/debug.h>
+#include <sys/abd.h>
 
 #define	EDONR_MODE		512
 #define	EDONR_BLOCK_SIZE	EdonR512_BLOCK_SIZE

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2010,7 +2010,6 @@ static int
 spa_load_verify_cb(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
     const zbookmark_phys_t *zb, const dnode_phys_t *dnp, void *arg)
 {
-
 	if (bp == NULL || BP_IS_HOLE(bp) || BP_IS_EMBEDDED(bp))
 		return (0);
 	/*

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -52,6 +52,7 @@
  * more than) this number of metaslabs.
  */
 int metaslabs_per_vdev = 200;
+#include <sys/abd.h>
 
 /*
  * Virtual device management.

--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -833,7 +833,7 @@ vdev_disk_io_start(zio_t *zio)
 	bp = &vb->vb_buf;
 
 	ASSERT(bp != NULL);
-	ASSERT(zio->io_data != NULL);
+	ASSERT(zio->io_abd != NULL);
 	ASSERT(zio->io_size != 0);
 
 	bioinit(bp);

--- a/module/zfs/vdev_queue.c
+++ b/module/zfs/vdev_queue.c
@@ -38,6 +38,7 @@
 #include <sys/spa.h>
 #include <sys/spa_impl.h>
 #include <sys/kstat.h>
+#include <sys/abd.h>
 
 /*
  * ZFS I/O Scheduler

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -976,7 +976,9 @@ vdev_raidz_reconstruct_q(raidz_map_t *rm, int *tgts, int ntgts)
 		dst = rm->rm_col[x].rc_abd;
 
 		if (c == rm->rm_firstdatacol) {
-			abd_copy(dst, src, size);
+			ASSERT3P(dst,!=,src);
+			if (dst != src)
+				abd_copy(dst, src, size);
 			if (rm->rm_col[x].rc_size > size)
 				abd_zero_off(dst, size,
 				    rm->rm_col[x].rc_size - size);

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -137,11 +137,20 @@ zio_init(void)
 	 * for each sixteenth-power of 2 below 128k and each eighth
 	 * power-of-two above 128k.
 	 */
+
+#define KMF_DEADBEEF    0x00000002      /* deadbeef checking */
+#define KMF_REDZONE             0x00000004      /* redzone checking */
+#define KMF_CONTENTS    0x00000008      /* freed-buffer content logging */
+#define KMF_LITE        0x00000100      /* lightweight debugging */
+#define KMF_HASH                0x00000200      /* cache has hash table */
+#define KMF_BUFTAG      (KMF_DEADBEEF | KMF_REDZONE)
+
 	for (c = 0; c < SPA_MAXBLOCKSIZE >> SPA_MINBLOCKSHIFT; c++) {
 		size_t size = (c + 1) << SPA_MINBLOCKSHIFT;
 		size_t p2 = size;
 		size_t align = 0;
-		size_t cflags = (size > zio_buf_debug_limit) ? KMC_NODEBUG : 0;
+		//size_t cflags = (size > zio_buf_debug_limit) ? KMC_NODEBUG : 0;
+		size_t cflags = KMF_BUFTAG | KMF_HASH | KMF_LITE;
 
 #ifdef _ILP32
 		/*
@@ -386,8 +395,13 @@ zio_subblock(zio_t *zio, abd_t *data, uint64_t size)
 {
 	ASSERT(zio->io_size > size);
 
-	if (zio->io_type == ZIO_TYPE_READ)
-		abd_copy(data, zio->io_abd, size);
+	if (zio->io_type == ZIO_TYPE_READ) {
+		ASSERT3P(data,!=,zio->io_abd);
+		ASSERT3S(data->abd_size,==,size);
+		ASSERT3S(zio->io_abd->abd_size,>=,size);
+		// copy first size bytes of zio->io_abd into data
+		abd_copy_off(data, zio->io_abd, 0, 0, size);
+	}
 }
 
 static void


### PR DESCRIPTION
O3X's vmem layer is a client of one of xnu's kernel memory
allocators, and has to accomplish a balancing act between:

a) not talking too often to xnu, because xnu's allocator
will stall the whole system dealing with large numbers of
simultaneous requests (vmem and kmem do heavy concurrency
on multiprocessor systems) and because xnu's freelist
handling degrades badly when dealing with many small
allocations and frees

b) reasonable overall memory (and CPU) use for ZFS

(There is a secondary goal (c) namely visibility into the
memory system via kstats).

Before ABD the tension between the two was driven by the
observation that the strongest memory use was compressed
ARC buffers, which come in discrete sizes due to the
minimum SPA block size and larger ashifts on vdevs.
We segregated the allocations by size as much as possible
and found a good balance between (a) and (b).

ABD removes the segregation of compressed ARC buffers by
scattering them into 1k chunks in their own arena.

This broke the balance between (a) and (b), leading to a
huge ballooning of fragmentation, leading to either or
both of huge overall memory consumption or a tiny ARC.

This patch recovers a decent balance between (a) and (b)
by (1) adjusting the vmem and kmem plumbing of the tree of
arenas under the abd_chunk cache and the other large and
busy kmem caches and (2) introducing a system that
attempts to defragment the quantum caches and vmem bucket
when it eventually appears (e.g. after a large eviction
after an ARC has accumulated on a multi-processor system
doing multi-threaded I/O, which leads to maximal
scattering of large ARC buffers into multiple segments and
spans shared with smaller buffers with longer lifespans).

The moving system spawns a thread in arc.c that
periodically checks for fragmentation and, finding it,
subject to timeout, walks the ARC multilists from their
heads looking for candidate ABDs to move.  We lock ABD
access with a new per-ABD mutex, and move the locked data
into newly allocated memory.  This "unsticks" old abd
chunks that "kidnap" spans that are otherwise freeable and
unlikely to be immediately allocated into by new ABD
allocations.  We also keep a per-ABD hrtime value so we do
not move ephemeral ABDs or immediately re-move ABDs which
have been recently moved.

For visibility several new abdstat and arcstat kstats have
been made.

arc_meta_min has also been reduced.  At pool import time
with ashift=9 and multiple vdevs and datasets, a large
amount of 512-byte metadata is pulled into abd (which uses
1k chunks).  Especially where mds and mdworker operate on
the datasets immediately after they are mounted, this
"early' metadata is mixed in with larger "early" file data
block allocation.  When the file data blocks are evicted,
many kmem_cache spans remain "kidnapped" by the small
metadata which, given a large arc_meta_min stays put
perhaps for the whole system uptime, even if the metaddata
is not reused at all.  With a smaller arc_meta_min,
low-value at-import metadata does not linger
counterproductively, but high-value metadata at import and
since import still gets a good share of the overall ARC
memory (this can be seen in the kstats) and is protected
from extreme ARC shrinks.

As arc_meta_min is runtime tunable, users with unusually
heavy "late" metadata activity can boost arc_meta_min to
suit their workloads.  However we should not hurt all
users principally for the benefit users who (as concrete
examples of high-metadata workload) turn on deduplication
or who set both a large count property and a small
recordsize/volblocksize property

Additionally:

* fixes for DEBUG userland and kernel building and operation