### PR TITLE
rework arc to avoid stall in arc_get_data_impl() (issue 548)

### DIFF
--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -811,6 +811,7 @@ dmu_tx_delay(dmu_tx_t *tx, uint64_t dirty)
 	dp->dp_last_wakeup = wakeup;
 	mutex_exit(&dp->dp_lock);
 
+	DMU_TX_STAT_BUMP(dmu_tx_dirty_delay);
 	zfs_sleep_until(wakeup);
 }
 

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -1278,7 +1278,7 @@ dsl_dir_tempreserve_space(dsl_dir_t *dd, uint64_t lsize, uint64_t asize,
 			 * locks are held.
 			 */
 			txg_delay(dd->dd_pool, tx->tx_txg,
-			    MSEC2NSEC(10), MSEC2NSEC(10));
+			    MSEC2NSEC(1), MSEC2NSEC(1));
 			err = SET_ERROR(ERESTART);
 		}
 	}


### PR DESCRIPTION
Even with ample system memory, threads can stall on the
cv_wait(&arc_reclaim_waiters_cv, ...) call in arc_get_data_impl().

This is particularly obvious when the only zfs activity is
a single writer creating a mix of small and large files in
a zfs dataset, as with "tar -xf .../xcode.tar".

1. Break up the cv_wait() into a loop that can be exited
   early under favourable conditions.

2. arc_reclaim_thread() should wake up any waiters under
   favourable conditions; it only did so if it was not
able to evict anything (or if it didn't need to).  This
could result in arbitrarily long cv_wait(&arc_reclaim_waiters_cv, ...)
while the reclaim thread evicted tiny amounts of memory
while arc was near the configured minimum.

3. Wake up the reclaim thread less often, and avoid
   spurious cv_signal(&arc_reclaim_thread_cv) calls.

4. Reap less often.   arc_kmem_reap_now() should not
   pester spl too frequently.

5. Avoid some redundant activity in the reclaim thread.

6. Fix arc_memory_throttle()'s non-shrinking page_load.

7. arc_is_overflowing should return B_FALSE if enough free
   system memory, even if arc_c is small; this reduces
the amount of times the new wait loop (item 1 above) is entered.

8. Fix arc_no_grow being B_TRUE for too long, especially
   when there is ample system memory.

9. Add some arcstats (and a dmu_tx stat) above msleep() calls
for insight.

10. shorten the amount of time waiting if dsl_dir_tempreserve_space() gets
an EAGAIN from arc_tempreserve_space().