### PR TITLE
fixes for https://github.com/openzfsonosx/zfs/issues/598

### DIFF
--- a/include/sys/abd.h
+++ b/include/sys/abd.h
@@ -119,8 +119,8 @@ abd_copy(abd_t *dabd, abd_t *sabd, size_t size)
 	ASSERT3P(sabd,!=,NULL);
 	ASSERT3P(dabd,!=,sabd);
 	if (dabd != sabd) {
-		ASSERT3S(dabd->abd_size,==,size);
-		ASSERT3S(sabd->abd_size,==,size);
+		ASSERT3S((size_t)dabd->abd_size,==,size);
+		ASSERT3S((size_t)sabd->abd_size,==,size);
 		abd_copy_off(dabd, sabd, 0, 0, size);
 	}
 }
@@ -128,28 +128,28 @@ abd_copy(abd_t *dabd, abd_t *sabd, size_t size)
 static inline void
 abd_copy_from_buf(abd_t *abd, void *buf, size_t size)
 {
-	ASSERT3S(abd->abd_size,==,size);
+	ASSERT3S((size_t)abd->abd_size,==,size);
 	abd_copy_from_buf_off(abd, buf, 0, size);
 }
 
 static inline void
 abd_copy_to_buf(void* buf, abd_t *abd, size_t size)
 {
-	ASSERT3S(abd->abd_size,==,size);
+	ASSERT3S((size_t)abd->abd_size,==,size);
 	abd_copy_to_buf_off(buf, abd, 0, size);
 }
 
 static inline int
 abd_cmp_buf(abd_t *abd, void *buf, size_t size)
 {
-	ASSERT3S(abd->abd_size,==,size);
+	ASSERT3S((size_t)abd->abd_size,==,size);
 	return (abd_cmp_buf_off(abd, buf, 0, size));
 }
 
 static inline void
 abd_zero(abd_t *abd, size_t size)
 {
-	ASSERT3S(abd->abd_size,==,size);
+	ASSERT3S((size_t)abd->abd_size,==,size);
 	abd_zero_off(abd, 0, size);
 }
 

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -4075,7 +4075,9 @@ zio_done(zio_t *zio)
 
 			if (asize != psize) {
 				adata = abd_alloc(asize, B_TRUE);
-				abd_copy(adata, zio->io_abd, psize);
+				ASSERT3S(adata->abd_size,>=,psize);
+				ASSERT3S(zio->io_abd->abd_size,>=,psize);
+				abd_copy_off(adata, zio->io_abd, 0, 0, psize);
 				abd_zero_off(adata, psize, asize - psize);
 			}
 

--- a/module/zfs/zio_checksum.c
+++ b/module/zfs/zio_checksum.c
@@ -335,7 +335,8 @@ zio_checksum_compute(zio_t *zio, enum zio_checksum checksum,
 
 		if (checksum == ZIO_CHECKSUM_ZILOG2) {
 			zil_chain_t zilc;
-			abd_copy_to_buf(&zilc, abd, sizeof (zil_chain_t));
+			ASSERT3S(abd->abd_size,>=,sizeof (zil_chain_t));
+			abd_copy_to_buf_off(&zilc, abd, 0, sizeof (zil_chain_t));
 
 			size = P2ROUNDUP_TYPED(zilc.zc_nused, ZIL_MIN_BLKSZ,
 			    uint64_t);
@@ -405,7 +406,8 @@ zio_checksum_error_impl(spa_t *spa, blkptr_t *bp, enum zio_checksum checksum,
 			zil_chain_t zilc;
 			uint64_t nused;
 
-			abd_copy_to_buf(&zilc, abd, sizeof (zil_chain_t));
+			ASSERT3S(abd->abd_size,>=,sizeof (zil_chain_t));
+			abd_copy_to_buf_off(&zilc, abd, 0, sizeof (zil_chain_t));
 
 			eck = zilc.zc_eck;
 			eck_offset = offsetof(zil_chain_t, zc_eck) +


### PR DESCRIPTION
These fixes make a DEBUG zfs.kext and zdb work.

abd.c API differs among ZOL, Illumos and O3X (the
latter two are the closest).

In particular abd_copy() no longer takes a size argument.

For O3X and Illumos it seems like bad practice to use
abd_copy() when the source and destination abds are of
dissimilar size.  O3X will ASSERT in this case, and in the
others range-checking is poor.  There are similar problems
for abd_copy_from_buf() and others.

Instead, when two ABDs are dissimilar, one should do a
range-checking with ASSERTs above the call site and then
use the _off() variants.  For example:

ASSERT3S(srcabd->abd_size, >=, copysize);
ASSERT3S(dstabd->abd_size, >=, copysize);
abd_copy_off(srcabd, dstabd, 0, 0, copysize);

This makes the intention that there will be uncopied bytes
left in one or the other ABD.

abd.h and abd.c functions can use some DEBUG
range-checking ASSERTs in the *_off() functions.

Add in further defensive ASSERTs in abd.c.