### PR TITLE
Squash kmem_alloc_128 and kmem_va_4096 leak, avoid superfluous allocs

### DIFF
--- a/include/sys/abd.h
+++ b/include/sys/abd.h
@@ -95,6 +95,8 @@ void *abd_borrow_buf(abd_t *, size_t);
 void *abd_borrow_buf_copy(abd_t *, size_t);
 void abd_return_buf(abd_t *, void *, size_t);
 void abd_return_buf_copy(abd_t *, void *, size_t);
+void abd_return_buf_copy_off(abd_t *, void *, size_t, size_t, size_t);
+void abd_return_buf_off(abd_t *, void *, size_t, size_t, size_t);
 void abd_take_ownership_of_buf(abd_t *, boolean_t);
 void abd_release_ownership_of_buf(abd_t *);
 

--- a/include/sys/kstat_osx.h
+++ b/include/sys/kstat_osx.h
@@ -144,6 +144,8 @@ typedef struct osx_kstat {
 
 	kstat_named_t zfs_vdev_queue_depth_pct;
 	kstat_named_t zio_dva_throttle_enabled;
+
+	kstat_named_t zfs_vdev_file_size_mismatch_cnt;
 } osx_kstat_t;
 
 
@@ -241,6 +243,8 @@ extern uint64_t dbuf_cache_max_bytes;
 
 extern uint64_t zfs_vdev_queue_depth_pct;
 extern boolean_t zio_dva_throttle_enabled;
+
+extern uint64_t zfs_vdev_file_size_mismatch_cnt;
 
 int        kstat_osx_init(void);
 void       kstat_osx_fini(void);

--- a/module/zfs/vdev_file.c
+++ b/module/zfs/vdev_file.c
@@ -204,6 +204,11 @@ vdev_file_close(vdev_t *vd)
 	vd->vdev_tsd = NULL;
 }
 
+/*
+ * count the number of mismatches of zio->io_size and zio->io_abd->abd_size below
+ */
+_Atomic uint64_t zfs_vdev_file_size_mismatch_cnt = 0;
+
 static void
 vdev_file_io_start(zio_t *zio)
 {
@@ -245,34 +250,25 @@ vdev_file_io_start(zio_t *zio)
 	    TQ_PUSHPAGE), !=, 0);
 		*/
 
-	    /*
-	     * deal with mismatch between abd_size and io_size :
-	     * make a new abd
-	     */
-	    if (zio->io_abd->abd_size != zio->io_size) {
-		    ASSERT3U(zio->io_abd->abd_size,>=,zio->io_size);
-		    // cf. zio_write_phys()
 #ifdef DEBUG
+	    if (zio->io_abd->abd_size != zio->io_size) {
+		    zfs_vdev_file_size_mismatch_cnt++;
+
 		    // this dprintf can be very noisy
-		    dprintf("%s: trimming zio->io_abd from 0x%x to 0x%llx\n",
+		    dprintf("ZFS: %s: trimming zio->io_abd from 0x%x to 0x%llx\n",
 			__func__, zio->io_abd->abd_size, zio->io_size);
-#endif
-		    abd_t *tabd = abd_alloc_sametype(zio->io_abd, zio->io_size);
-		    abd_copy_off(tabd, zio->io_abd, 0, 0, zio->io_size);
-
-		    zio_push_transform(zio, tabd, zio->io_size, zio->io_size, NULL);
 	    }
-
+#endif
 		void *data;
 
 		if (zio->io_type == ZIO_TYPE_READ) {
 			ASSERT3S(zio->io_abd->abd_size,>=,zio->io_size);
 			data =
-				abd_borrow_buf(zio->io_abd, zio->io_size);
+				abd_borrow_buf(zio->io_abd, zio->io_abd->abd_size);
 		} else {
 			ASSERT3S(zio->io_abd->abd_size,>=,zio->io_size);
 			data =
-				abd_borrow_buf_copy(zio->io_abd, zio->io_size);
+				abd_borrow_buf_copy(zio->io_abd, zio->io_abd->abd_size);
 		}
 
 		zio->io_error = vn_rdwr(zio->io_type == ZIO_TYPE_READ ?
@@ -283,10 +279,18 @@ vdev_file_io_start(zio_t *zio)
         vnode_put(vf->vf_vnode);
 
 		if (zio->io_type == ZIO_TYPE_READ) {
-			abd_return_buf_copy(zio->io_abd, data, zio->io_size);
+			if (zio->io_abd->abd_size == zio->io_size) {
+				abd_return_buf_copy(zio->io_abd, data, zio->io_size);
+			} else {
+				VERIFY3S(zio->io_abd->abd_size,>=,zio->io_size);
+				abd_return_buf_copy_off(zio->io_abd, data,
+				    0, zio->io_size, zio->io_abd->abd_size);
+			}
 		} else {
-			abd_return_buf(zio->io_abd, data, zio->io_size);
+			VERIFY3S(zio->io_abd->abd_size,>=,zio->io_size);
+			abd_return_buf_off(zio->io_abd, data, 0, zio->io_size, zio->io_abd->abd_size);
 		}
+
     }
 
     if (resid != 0 && zio->io_error == 0)

--- a/module/zfs/zfs_kstat_osx.c
+++ b/module/zfs/zfs_kstat_osx.c
@@ -175,6 +175,8 @@ osx_kstat_t osx_kstat = {
 
 	{"zfs_vdev_queue_depth_pct",KSTAT_DATA_UINT64  },
 	{"zio_dva_throttle_enabled",KSTAT_DATA_UINT64  },
+
+	{"zfs_vdev_file_size_mismatch_cnt",KSTAT_DATA_UINT64  },
 };
 
 
@@ -558,6 +560,8 @@ static int osx_kstat_update(kstat_t *ksp, int rw)
 
 		ks->zfs_vdev_queue_depth_pct.value.ui64 = zfs_vdev_queue_depth_pct;
 		ks->zio_dva_throttle_enabled.value.ui64 = (uint64_t) zio_dva_throttle_enabled;
+
+		ks->zfs_vdev_file_size_mismatch_cnt.value.ui64 = zfs_vdev_file_size_mismatch_cnt;
 	}
 
 	return 0;


### PR DESCRIPTION
Simplify vdev_file_io_start abd/zio size mismatch handling

1. avoid the extra allocations that the zio_push_transform
   approach incurred

2. abd_borrow zio->io_abd->abd_size rather than zio->io_size

3. abd_return_buf and abd_return_buf_copy assertions fail
   in the zio->io_size != zio->io_abd->abd_size case, so
   write two new _return_*off functions in abd.c that take
   a range and a total buffer size

Also:

Add a new kstat that counds size mismatches between
zio->io_size and abd->abd_size in vdev_file_io_start().

Fix mis-counting of is_metadata_linear abdstat.