### PR TITLE
don't use FOFFMAX or FRSYNC

### DIFF
--- a/lib/libspl/include/sys/file.h
+++ b/lib/libspl/include/sys/file.h
@@ -37,10 +37,10 @@
 
 #define FCREAT  O_CREAT
 #define FTRUNC  O_TRUNC
-#define FOFFMAX 0
+//#define FOFFMAX 0
 #define FSYNC   O_SYNC
 #define FDSYNC  O_DSYNC
-#define FRSYNC  O_RSYNC
+//#define FRSYNC  O_RSYNC
 #define FEXCL   O_EXCL
 
 #define O_DIRECT 0

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -157,7 +157,11 @@ spa_config_write(spa_config_dirent_t *dp, nvlist_t *nvl)
 	size_t buflen;
 	char *buf;
 	vnode_t *vp;
+#ifndef __APPLE__
 	int oflags = FWRITE | FTRUNC | FCREAT | FOFFMAX;
+#else
+	int oflags = FWRITE | FTRUNC | FCREAT;
+#endif
 #ifdef __linux__
 	int error;
 #endif

--- a/module/zfs/vdev_file.c
+++ b/module/zfs/vdev_file.c
@@ -123,7 +123,11 @@ vdev_file_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 
     error = vn_openat(vd->vdev_path + 1,
                       UIO_SYSSPACE,
+#ifndef __APPLE__
                       spa_mode(vd->vdev_spa) | FOFFMAX,
+#else
+                      spa_mode(vd->vdev_spa),
+#endif
                       0,
                       &vp,
                       0,

--- a/module/zfs/zfs_replay.c
+++ b/module/zfs/zfs_replay.c
@@ -753,8 +753,13 @@ zfs_replay_truncate(zfsvfs_t *zsb, lr_truncate_t *lr, boolean_t byteswap)
 	fl.l_start = lr->lr_offset;
 	fl.l_len = lr->lr_length;
 
+#ifndef __APPLE__
 	error = zfs_space(ZTOV(zp), F_FREESP, &fl, FWRITE | FOFFMAX,
                       lr->lr_offset, kcred, NULL);
+#else
+	error = zfs_space(ZTOV(zp), F_FREESP, &fl, FWRITE,
+                      lr->lr_offset, kcred, NULL);
+#endif
 
 	vnode_put(ZTOV(zp));
 

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -654,9 +654,14 @@ zfs_read(vnode_t *vp, uio_t *uio, int ioflag, cred_t *cr, caller_context_t *ct)
 	/*
 	 * If we're in FRSYNC mode, sync out this znode before reading it.
 	 */
+#ifndef __APPLE__
 	if (zfsvfs->z_log &&
 	    (ioflag & FRSYNC || zfsvfs->z_os->os_sync == ZFS_SYNC_ALWAYS))
 		zil_commit(zfsvfs->z_log, zp->z_id);
+#else
+	if (zfsvfs->z_log && zfsvfs->z_os->os_sync == ZFS_SYNC_ALWAYS)
+		zil_commit(zfsvfs->z_log, zp->z_id);
+#endif
 
 	/*
 	 * Lock the range against changes.

--- a/module/zfs/zfs_vnops_osx_lib.c
+++ b/module/zfs/zfs_vnops_osx_lib.c
@@ -603,7 +603,11 @@ zfs_ioflags(int ap_ioflag)
 	if (ap_ioflag & IO_NDELAY)
 		flags |= FNONBLOCK;
 	if (ap_ioflag & IO_SYNC)
+#ifndef __APPLE__
 		flags |= (FSYNC | FDSYNC | FRSYNC);
+#else
+		flags |= (FSYNC | FDSYNC);
+#endif
 
 	return (flags);
 }


### PR DESCRIPTION
we no longer define them (wrongly) in spl or libspl

zfs half fix of https://github.com/openzfsonosx/spl/issues/17