### PR TITLE
zfs_vnop_pageoutv2 must clear the dirty bit when committing the UPL

### DIFF
--- a/module/zfs/zfs_vnops_osx.c
+++ b/module/zfs/zfs_vnops_osx.c
@@ -2691,7 +2691,10 @@ zfs_vnop_pageoutv2(struct vnop_pageout_args *ap)
 	if (error)
 		ubc_upl_abort(upl,  (UPL_ABORT_ERROR | UPL_ABORT_FREE_ON_EMPTY));
 	else
-		ubc_upl_commit_range(upl, 0, a_size, UPL_COMMIT_FREE_ON_EMPTY);
+		ubc_upl_commit_range(upl, 0, a_size,
+		    UPL_COMMIT CLEAR_DIRTY
+		    | UPL_COMMIT_CLEAR_PRECIOUS
+		    | UPL_COMMIT_FREE_ON_EMPTY);
 
 	upl = NULL;
 


### PR DESCRIPTION
The UPL is created with the UPL_RET_ONLY_DIRTY flag set,
which causes the VM system to clear the hardware (HW) dirty bit and
set the software (SW) dirty bit on the pages gathered into
the UPL.   After writing the dirty pages out to the file,
it is our responsibility to clear the SW dirty bit (as is
done in zfs_pageout) using UPL_COMMIT_CLEAR_DIRTY.   This
clears the SW dirty bit, but leaves the HW dirty bit
alone so that the VM system can detect that the page has
been redirtied (typically by something that has mmapped it).

If we leave the SW dirty bit set, the next page-dirtying
operation will create a copy object.   Our shadow chain of
copy objects can grow quite large in priniciple, but we
get into trouble when it's even just one copy, since the
underlying paged-out-but-SW-dirty pages will linger until
reaped.  This reaping typically is likely to be deferred
until the file system is unmounted, at which point the
shadow chain is paged out from the top downwards, with the
result that all the data for that page in the file is
reverted to the point at which it was paged out for the
first time since mounting.

In master, the following chain of events will trigger this
problem: 1) create a file, 2) mmap a page from the file:
for ease of reproduction, mmap the page containing the EOF
such that the file offset & PAGE_MASK_64 != 0, 3) dirty
the page, 4) force it through pageoutv2 (e.g. via msync or
memory pressure), 5) extend the file, e.g, by opening with
O_APPEND and writing something, 6) save a copy of the file
in a different filesystem, 7) unmount the source
filesystem, 8) remount the source filesystem, 9) compare
sizes and contents of the source file and the copy made in
step (6): the writes from step (5) will be missing.

(Indeed, any writes to that page will vanish at unmount;
the only condition is that the page has been through
pageoutv2).

This patch adds the UPL_COMMIT_CLEAR_DIRTY flag to the
ubc_upl_commit_range() in pageoutv2.  It *also* adds the
UPL_COMMIT_CLEAR_PRECIOUS flag out of paranoia that a
contrived set of operations involving zfs_{read,write} on
a file which has been mmapped can lead to the precious
flag being set.  

(A "precious" page is one that is not
dirty but which is believed by the VM system to not be in
the backing file; when we tell the kernel (via
UPL_COMMIT_CLEAR_PRECIOUS) that the page is now safely
stored, the kernel will shortlist it for eviction if
memory is needed.   A "precious" page that is dirtied can
also get a copy object attached to it, with similar
results to the more easily reproducible problem above.)