### PR TITLE
WIP: Avoid kmem_alloc in IO path

### DIFF
--- a/include/sys/ldi_buf.h
+++ b/include/sys/ldi_buf.h
@@ -32,6 +32,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
+
 /*
  * Buffer context for LDI strategy
  */
@@ -49,6 +50,11 @@ typedef struct ldi_buf {
 	int		b_error;	/* IO error code */
 	uint64_t	pad;		/* Pad to 64 bytes */
 } ldi_buf_t;				/* XXX Currently 64b */
+
+typedef struct vdev_buf {
+	ldi_buf_t	vb_buf;		/* buffer that describes the io */
+	void *vb_io;		/* pointer back to the original zio_t */
+} vdev_buf_t;
 
 ldi_buf_t *ldi_getrbuf(int);
 void ldi_freerbuf(ldi_buf_t *);

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -252,7 +252,7 @@ struct vdev {
 
 	/* pool checkpoint related */
 	space_map_t	*vdev_checkpoint_sm;	/* contains reserved blocks */
-	
+
 	boolean_t	vdev_initialize_exit_wanted;
 	vdev_initializing_state_t	vdev_initialize_state;
 	kthread_t	*vdev_initialize_thread;
@@ -499,14 +499,6 @@ extern boolean_t vdev_obsolete_counts_are_precise(vdev_t *vd);
  * Other miscellaneous functions
  */
 int vdev_checkpoint_sm_object(vdev_t *vd);
-
-/*
- * The vdev_buf_t is used to translate between zio_t and buf_t, and back again.
- */
-typedef struct vdev_buf {
-	ldi_buf_t	vb_buf;		/* buffer that describes the io */
-	zio_t	*vb_io;		/* pointer back to the original zio_t */
-} vdev_buf_t;
 
 #ifdef	__cplusplus
 }

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -36,6 +36,8 @@
 #include <sys/avl.h>
 #include <sys/fs/zfs.h>
 #include <sys/zio_impl.h>
+#include <sys/ldi_buf.h>
+
 
 #ifdef	__cplusplus
 extern "C" {
@@ -488,6 +490,10 @@ struct zio {
 	kmutex_t	io_lock;
 	kcondvar_t	io_cv;
 	int		io_allocator;
+
+#if __APPLE__
+	vdev_buf_t  io_ldi_buf;
+#endif
 
 	/* FMA state */
 	zio_cksum_report_t *io_cksum_report;

--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -711,7 +711,7 @@ vdev_disk_io_intr(ldi_buf_t *bp)
 		    0, zio->io_size, zio->io_abd->abd_size);
 	}
 
-	kmem_free(vb, sizeof (vdev_buf_t));
+	//kmem_free(vb, sizeof (vdev_buf_t));
 
 	zio_delay_interrupt(zio);
 }
@@ -838,7 +838,8 @@ vdev_disk_io_start(zio_t *zio)
 
 	zio->io_target_timestamp = zio_handle_io_delay(zio);
 
-	vb = kmem_alloc(sizeof (vdev_buf_t), KM_SLEEP);
+//	vb = kmem_alloc(sizeof (vdev_buf_t), KM_SLEEP);
+	vb = &(zio->io_ldi_buf);
 
 	vb->vb_io = zio;
 	bp = &vb->vb_buf;
@@ -892,7 +893,7 @@ vdev_disk_io_start(zio_t *zio)
 	if (error != 0) {
 		dprintf("%s error from ldi_strategy %d\n", __func__, error);
 		zio->io_error = EIO;
-		kmem_free(vb, sizeof (vdev_buf_t));
+		//kmem_free(vb, sizeof (vdev_buf_t));
 		zio_execute(zio);
 		// zio_interrupt(zio);
 	}


### PR DESCRIPTION
There appears to be some issues with too-frequent allocations in spl-kmem
and this is especially noticable due to allocations we do for each
read or write IO operation.
We embed the vdev_buf into zio struct itself, and since ldi_vnode has
to call buf_alloc() we also allow ldi_iokit to allocate a local holder.
(It is inconvenient to try to include C++ headers in zio.h).

If this does speed up IO, it is only because we now avoid the real problem
which is still something we should also address