### PR TITLE
fix git hash not showing up in kext_version

### DIFF
--- a/config/zfs-meta.m4
+++ b/config/zfs-meta.m4
@@ -69,7 +69,7 @@ AC_DEFUN([ZFS_AC_META], [
 		ZFS_META_RELEASE=_ZFS_AC_META_GETVAL([Release]);
 		if test ! -f ".nogitrelease" && git rev-parse --git-dir > /dev/null 2>&1; then
 			_match="${ZFS_META_NAME}-${ZFS_META_VERSION}*"
-			_alias=$(git describe --match=${_match} 2>/dev/null)
+			_alias=$(git describe --tags --match=${_match} 2>/dev/null)
 			_release=$(echo ${_alias}|cut -f3- -d'-')
 			if test -n "${_release}"; then
 				ZFS_META_RELEASE=${_release}


### PR DESCRIPTION
git describe only sees annotated tags by default, and as we match the name anyway, we can as well drop the requirement of annotation.

After this commit, `sysctl zfs.kext_version` will show the git commit again