### PR TITLE
remove hardcoded path for flock

### DIFF
--- a/cmd/zed/zed.d/zed-functions.sh
+++ b/cmd/zed/zed.d/zed-functions.sh
@@ -125,7 +125,7 @@ zed_lock()
     # Obtain a lock on the file bound to the given file descriptor.
     #
     eval "exec ${fd}> '${lockfile}'"
-    err="$(/opt/homebrew/bin/flock "${fd}" 2>&1)"
+    err="$(flock "${fd}" 2>&1)"
     if [ $? -ne 0 ]; then
         zed_log_err "failed to lock \"${lockfile}\": ${err}"
     fi
@@ -163,7 +163,7 @@ zed_unlock()
 
     # Release the lock and close the file descriptor.
     #
-    err="$(/opt/homebrew/bin/flock -u "${fd}" 2>&1)"
+    err="$(flock -u "${fd}" 2>&1)"
     if [ $? -ne 0 ]; then
         zed_log_err "failed to unlock \"${lockfile}\": ${err}"
     fi


### PR DESCRIPTION
homebrew default installs in /usr/local/bin wich should be in PATH when using flock from https://github.com/discoteq/flock

Fixes #510